### PR TITLE
Added fixes for some skipped test cases on the automation for api test cases

### DIFF
--- a/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
+++ b/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
@@ -18,7 +18,7 @@ public class SiteManagementAPI extends BaseAPI {
 		super(api, apiConnectionManager);
 	}
 
-	public void testCreateSite() {
+	public void testCreateSite(String siteId) {
 		Map<String, Object> json = new HashMap<>();
 		json.put("site_id", siteId);
 		json.put("description", description);
@@ -27,6 +27,7 @@ public class SiteManagementAPI extends BaseAPI {
 				.header("Location",
 						is(headerLocationBase + "/studio/api/1/services/api/1/site/get.json?site_id=" + siteId))
 				.json("$.message", is("OK")).debug();
+		this.setSiteId(siteId);;
 	}
 
 	public void testCreateSiteInvalidParameters() {
@@ -51,7 +52,7 @@ public class SiteManagementAPI extends BaseAPI {
 				.json("$.message", is("Site already exists")).debug();
 	}
 
-	public void testDeleteSite() {
+	public void testDeleteSite(String siteId) {
 		Map<String, Object> json = new HashMap<>();
 		json.put("siteId", siteId);
 		api.post("/studio/api/1/services/api/1/site/delete-site.json").json(json).execute().status(200);

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/AddUserToGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/AddUserToGroupAPITest.java
@@ -21,6 +21,7 @@ public class AddUserToGroupAPITest {
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
 	private UserManagementAPI userManagementAPI;
+	private String siteId="siteTestAddUserToGroupAPITest";
 
 	public AddUserToGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -35,7 +36,7 @@ public class AddUserToGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		userManagementAPI.testCreateUser();
 	}
@@ -68,7 +69,7 @@ public class AddUserToGroupAPITest {
 	@AfterTest
 	public void afterTest() {
 		userManagementAPI.testDeleteUser();
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/ClearConfigurationCacheAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/ClearConfigurationCacheAPITest.java
@@ -11,7 +11,8 @@ import org.testng.annotations.Test;
 public class ClearConfigurationCacheAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteTestClearConfigurationCacheAPITest";
+	
 	public ClearConfigurationCacheAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -23,7 +24,7 @@ public class ClearConfigurationCacheAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 1)
@@ -33,7 +34,7 @@ public class ClearConfigurationCacheAPITest {
 	
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateGroupAPITest.java
@@ -18,7 +18,7 @@ public class CreateGroupAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
-	
+	private String siteId="siteTestCreateGroupAPITest";
 
 	public CreateGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -32,7 +32,7 @@ public class CreateGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 1)
@@ -52,7 +52,7 @@ public class CreateGroupAPITest {
 	
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateSiteAPITest.java
@@ -16,6 +16,7 @@ public class CreateSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
+	private String siteId="siteTestCreateSiteAPITest";
 
 	public CreateSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -33,7 +34,7 @@ public class CreateSiteAPITest {
 
 	@Test(priority = 1)
 	public void testCreateSite() {
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 2)
@@ -48,7 +49,7 @@ public class CreateSiteAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteGroupAPITest.java
@@ -18,7 +18,8 @@ public class DeleteGroupAPITest {
 	private SiteManagementAPI siteManagementAPI;
 	private SecurityAPI securityAPI;
 	private GroupManagementAPI groupManagementAPI;
-
+	private String siteId="siteTestDeleteGroupAPITest";
+	
 	public DeleteGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -31,7 +32,7 @@ public class DeleteGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 	}
 
@@ -52,7 +53,7 @@ public class DeleteGroupAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteSiteAPITest.java
@@ -17,7 +17,8 @@ public class DeleteSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteTestDeleteSiteAPITest";
+	
 	public DeleteSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -29,12 +30,12 @@ public class DeleteSiteAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 1)
-	public void testCreateSite() {
-		siteManagementAPI.testDeleteSite();
+	public void testDeleteSite() {
+		siteManagementAPI.testDeleteSite(siteId);
 	}
 
 	@AfterTest

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/ExistsSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/ExistsSiteAPITest.java
@@ -16,7 +16,8 @@ public class ExistsSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteTestExistsSiteAPITest";
+	
 	public ExistsSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -28,7 +29,7 @@ public class ExistsSiteAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 1)
@@ -38,7 +39,7 @@ public class ExistsSiteAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetAuditLogAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetAuditLogAPITest.java
@@ -18,7 +18,8 @@ public class GetAuditLogAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private AuditAPI auditAPI;
-
+	private String siteId="siteGetAuditLogAPITest";
+	
 	public GetAuditLogAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -31,7 +32,7 @@ public class GetAuditLogAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 
 	}
 
@@ -52,7 +53,7 @@ public class GetAuditLogAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetConfigurationAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetConfigurationAPITest.java
@@ -16,7 +16,9 @@ public class GetConfigurationAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteGetConfigurationAPITest";
+	
+	
 	public GetConfigurationAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -28,7 +30,7 @@ public class GetConfigurationAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		
 	}
 
@@ -39,7 +41,7 @@ public class GetConfigurationAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupAPITest.java
@@ -18,7 +18,7 @@ public class GetGroupAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
-
+	private String siteId="siteGetGroupAPITest";
 
 	public GetGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -32,7 +32,7 @@ public class GetGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 	}
 
@@ -53,7 +53,7 @@ public class GetGroupAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupsAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupsAPITest.java
@@ -19,7 +19,7 @@ public class GetGroupsAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
-
+	private String siteId="siteGetGroupsAPITest";
 
 	public GetGroupsAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -33,7 +33,7 @@ public class GetGroupsAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		groupManagementAPI.testCreateStudioGroup02(siteManagementAPI.getSiteId());
 	}
@@ -45,7 +45,7 @@ public class GetGroupsAPITest {
 	
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupsPerSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetGroupsPerSiteAPITest.java
@@ -19,7 +19,7 @@ public class GetGroupsPerSiteAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
-
+	private String siteId="siteGetGroupsPerSiteAPITest";
 
 	public GetGroupsPerSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -33,7 +33,7 @@ public class GetGroupsPerSiteAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		groupManagementAPI.testCreateStudioGroup02(siteManagementAPI.getSiteId());
 	}
@@ -45,7 +45,7 @@ public class GetGroupsPerSiteAPITest {
 	
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSiteAPITest.java
@@ -16,7 +16,8 @@ public class GetSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteGetSiteAPITest";
+	
 	public GetSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -28,7 +29,7 @@ public class GetSiteAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 
 	}
 
@@ -44,7 +45,7 @@ public class GetSiteAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSitesPerUserAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSitesPerUserAPITest.java
@@ -16,7 +16,8 @@ public class GetSitesPerUserAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-
+	private String siteId="siteGetSitesPerUserAPITest";
+	
 	public GetSitesPerUserAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -28,7 +29,7 @@ public class GetSitesPerUserAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
 	@Test(priority = 1)
@@ -48,7 +49,7 @@ public class GetSitesPerUserAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserPerSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserPerSiteAPITest.java
@@ -20,7 +20,7 @@ public class GetUserPerSiteAPITest {
 	private UserManagementAPI userManagementAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
-	
+	private String siteId="siteGetUserPerSiteAPITest";
 
 	public GetUserPerSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -36,7 +36,7 @@ public class GetUserPerSiteAPITest {
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
 		userManagementAPI.testCreateUser();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		groupManagementAPI.testCreateStudioGroup02(siteManagementAPI.getSiteId());
 		groupManagementAPI.testAddUserToGroup01(userManagementAPI.getNewusername(), siteManagementAPI.getSiteId());
@@ -51,7 +51,7 @@ public class GetUserPerSiteAPITest {
 	@AfterTest
 	public void afterTest() {
 		userManagementAPI.testDeleteUser();
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 	

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUsersPerGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUsersPerGroupAPITest.java
@@ -20,7 +20,7 @@ public class GetUsersPerGroupAPITest {
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
 	private UserManagementAPI userManagementAPI;
-
+	private String siteId="siteGetUsersPerGroupAPITest";
 
 	public GetUsersPerGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -36,7 +36,7 @@ public class GetUsersPerGroupAPITest {
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
 		userManagementAPI.testCreateUser();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		groupManagementAPI.testAddUserToGroup01(userManagementAPI.getNewusername(), siteManagementAPI.getSiteId());
 	}
@@ -55,7 +55,7 @@ public class GetUsersPerGroupAPITest {
 	
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		userManagementAPI.testDeleteUser();
 		securityAPI.logOutFromStudioUsingAPICall();
 	}

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/RebuildDataBaseAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/RebuildDataBaseAPITest.java
@@ -18,7 +18,8 @@ public class RebuildDataBaseAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private RepoManagementAPI repoManagementAPI;
-
+	private String siteId="siteRebuildDataBaseAPITest";
+	
 	public RebuildDataBaseAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -31,7 +32,7 @@ public class RebuildDataBaseAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
     @Test(priority=1)
@@ -48,7 +49,7 @@ public class RebuildDataBaseAPITest {
     
     @AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
     

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/RemoveUserFromGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/RemoveUserFromGroupAPITest.java
@@ -19,7 +19,8 @@ public class RemoveUserFromGroupAPITest {
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
 	private UserManagementAPI userManagementAPI;
-
+	private String siteId="siteRemoveUserFromGroupAPITest";
+	
 	public RemoveUserFromGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -33,7 +34,7 @@ public class RemoveUserFromGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 		userManagementAPI.testCreateUser();
 		groupManagementAPI.testAddUserToGroup01(userManagementAPI.getNewusername(), siteManagementAPI.getSiteId());
@@ -63,7 +64,7 @@ public class RemoveUserFromGroupAPITest {
 	@AfterTest
 	public void afterTest() {
 		userManagementAPI.testDeleteUser();
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 	

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/SyncFromRepoAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/SyncFromRepoAPITest.java
@@ -18,7 +18,8 @@ public class SyncFromRepoAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private RepoManagementAPI repoManagementAPI;
-
+	private String siteId="siteSyncFromRepoAPITest";
+	
 	public SyncFromRepoAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
@@ -31,7 +32,7 @@ public class SyncFromRepoAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 	}
 
     @Test(priority=1)
@@ -52,7 +53,7 @@ public class SyncFromRepoAPITest {
     
     @AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
     

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/UpdateGroupAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/UpdateGroupAPITest.java
@@ -17,6 +17,7 @@ public class UpdateGroupAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private GroupManagementAPI groupManagementAPI;
+	private String siteId="siteUpdateGroupAPITest";
 
 	public UpdateGroupAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();
@@ -30,7 +31,7 @@ public class UpdateGroupAPITest {
 	@BeforeTest
 	public void beforeTest() {
 		securityAPI.logInIntoStudioUsingAPICall();
-		siteManagementAPI.testCreateSite();
+		siteManagementAPI.testCreateSite(siteId);
 		groupManagementAPI.testCreateStudioGroup01(siteManagementAPI.getSiteId());
 	}
 
@@ -52,7 +53,7 @@ public class UpdateGroupAPITest {
 
 	@AfterTest
 	public void afterTest() {
-		siteManagementAPI.testDeleteSite();
+		siteManagementAPI.testDeleteSite(siteId);
 		securityAPI.logOutFromStudioUsingAPICall();
 	}
 


### PR DESCRIPTION
Root cause: the site is already created with the same siteId so in the before test will fail, and it provokes that the test methods will skipped.
(Already fixed)
### Ticket reference or full description of what's in the PR
