### PR TITLE
Added fixes for non-valid text (element text) on check for dependencies dialog

### DIFF
--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DeleteOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DeleteOptionTest.java
@@ -89,10 +89,14 @@ public class DeleteOptionTest extends StudioBaseTest {
 
 		previewPage.clickOnOKDeleteDependencies();
 
+		this.driverManager.waitUntilSidebarOpens();
+		this.driverManager.waitForAnimation();
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", studioLogo).click();
 
 		this.driverManager.waitForAnimation();
 		this.driverManager.waitForFullExpansionOfTree();
+		
+		this.driverManager.waitForAnimation();
 		String contentDelete = this.driverManager
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", testingItemURLXpath).getText();
 		Assert.assertEquals(contentDelete, "/test1");

--- a/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
@@ -545,6 +545,8 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForAnimation();
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(itemText));
@@ -661,6 +663,8 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForAnimation();
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(staticAssetName));
@@ -754,6 +758,8 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForAnimation();
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(staticAssetName));
@@ -840,6 +846,8 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForAnimation();
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(scriptName));
@@ -1154,6 +1162,8 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForAnimation();
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(templateName));
@@ -1271,6 +1281,7 @@ public class PreviewPage {
 		driverManager.getDriver().switchTo().activeElement();
 		driverManager.waitUntilPageLoad();
 		// checking if the item name is the correct on the dependencies dialog
+		this.driverManager.waitForFullExpansionOfTree();
 		WebElement dependenciesForItemElement = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dependenciesForXpath);
 		Assert.assertTrue(dependenciesForItemElement.getText().equalsIgnoreCase(componentName));


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Added fix for failed test cases:
DependenciesCalculationRefersToAnItemTest
DependenciesCalculationItemRefersToTest