### PR TITLE
Added fix for a failed test case on delivery check.

### DIFF
--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/CreateSiteWithWebSiteEditorialBluePrintTestForDeliveryCheck.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/CreateSiteWithWebSiteEditorialBluePrintTestForDeliveryCheck.java
@@ -18,6 +18,7 @@ package org.craftercms.studio.test.cases.sitestestcases;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.craftercms.studio.test.cases.StudioBaseTest;
+import org.craftercms.studio.test.utils.FilesLocations;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -87,6 +88,6 @@ public class CreateSiteWithWebSiteEditorialBluePrintTestForDeliveryCheck extends
 		Assert.assertTrue(exitCode == 0, "Init site process failed");
 
 		// saving the siteId for the dependent test cases to this test case.
-		deliveryExecutionValuesManager.setProperty("general.currentsiteid", siteId);
+		deliveryExecutionValuesManager.setProperty("general.currentsiteid", siteId, FilesLocations.DELIVERYEXECUTIONVALUESPROPERTIESFILEPATH);
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/utils/ConstantsPropertiesManager.java
+++ b/src/test/java/org/craftercms/studio/test/utils/ConstantsPropertiesManager.java
@@ -45,11 +45,11 @@ public class ConstantsPropertiesManager {
 		this.sharedExecutionConstants = sharedExecutionConstants;
 	}
 
-	public void setProperty(String key, String value) {
+	public void setProperty(String key, String value, String filePath) {
 
 		FileOutputStream fileOutputStream;
 		try {
-			fileOutputStream = new FileOutputStream(FilesLocations.CONSTANTSPROPERTIESFILEPATH);
+			fileOutputStream = new FileOutputStream(filePath);
 			this.sharedExecutionConstants.setProperty(key, value);
 			this.sharedExecutionConstants.store(fileOutputStream, null);
 			fileOutputStream.close();


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Added missing param to setProperty File that provokes that the file manager write the current.siteid on the wrong file location.