### PR TITLE
Feature/fixes310

### DIFF
--- a/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
+++ b/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
@@ -30,7 +30,7 @@ public class SiteManagementAPI extends BaseAPI {
 
 	private String siteId = "mysite";
 	private String description = "Description!";
-	private String blueprint = "empty";
+	private String blueprint = "org.craftercms.blueprint.empty";
 
 	public SiteManagementAPI(JsonTester api, APIConnectionManager apiConnectionManager) {
 		super(api, apiConnectionManager);

--- a/src/test/java/org/craftercms/studio/test/api2/objects/MonitoringAPI2.java
+++ b/src/test/java/org/craftercms/studio/test/api2/objects/MonitoringAPI2.java
@@ -15,10 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.craftercms.studio.test.api.objects;
+package org.craftercms.studio.test.api2.objects;
 
 
 import org.apache.http.HttpStatus;
+import org.craftercms.studio.test.api.objects.BaseAPI;
 import org.craftercms.studio.test.utils.APIConnectionManager;
 import org.craftercms.studio.test.utils.JsonTester;
 
@@ -26,23 +27,23 @@ import org.craftercms.studio.test.utils.JsonTester;
  * @author chris lim
  *
  */
-public class MonitoringAPI extends BaseAPI {
+public class MonitoringAPI2 extends BaseAPI {
 
 
-	public MonitoringAPI(JsonTester api, APIConnectionManager apiConnectionManager) {
+	public MonitoringAPI2(JsonTester api, APIConnectionManager apiConnectionManager) {
 		super(api, apiConnectionManager);
 	}
 
  	public void testVersion(){
-   		api.get("studio/api/1/services/api/1/monitor/version.json").execute().status(HttpStatus.SC_OK).debug();
+   		api.get("studio/api/2/monitoring/version.json").execute().status(HttpStatus.SC_OK).debug();
  	}
  	
  	public void testStatus(){
-   		api.get("studio/api/1/services/api/1/monitor/status.json").execute().status(HttpStatus.SC_OK).debug();
+   		api.get("studio/api/2/monitoring/status.json").execute().status(HttpStatus.SC_OK).debug();
  	}
 
  	public void testMemory(){
-   		api.get("studio/api/1/services/api/1/monitor/memory.json").execute().status(HttpStatus.SC_OK).debug();
+   		api.get("studio/api/2/monitoring/memory.json").execute().status(HttpStatus.SC_OK).debug();
  	}
  	
 }

--- a/src/test/java/org/craftercms/studio/test/cases/api2testcases/MemoryAPI2Test.java
+++ b/src/test/java/org/craftercms/studio/test/cases/api2testcases/MemoryAPI2Test.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.craftercms.studio.test.cases.apitestcases;
+package org.craftercms.studio.test.cases.api2testcases;
 
-import org.craftercms.studio.test.api.objects.MonitoringAPI;
+import org.craftercms.studio.test.api2.objects.MonitoringAPI2;
 import org.craftercms.studio.test.api.objects.SecurityAPI;
 import org.craftercms.studio.test.utils.APIConnectionManager;
 import org.craftercms.studio.test.utils.JsonTester;
@@ -28,18 +28,18 @@ import org.testng.annotations.Test;
  * Created by gustavo ortiz
  */
 
-public class VersionAPITest {
+public class MemoryAPI2Test {
 
-    private MonitoringAPI monitoringAPI;
+    private MonitoringAPI2 monitoringAPI2;
     private SecurityAPI securityAPI;
     
-    public VersionAPITest(){
+    public MemoryAPI2Test(){
     	APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
 				apiConnectionManager.getPort());
-		
+    	
 		securityAPI = new SecurityAPI(api, apiConnectionManager);
-    	monitoringAPI = new MonitoringAPI(api, apiConnectionManager);
+		monitoringAPI2 = new MonitoringAPI2(api, apiConnectionManager);
     }
 
     @BeforeTest
@@ -48,8 +48,8 @@ public class VersionAPITest {
 	}
     
     @Test(priority=1)
-    public void testVersion(){
-    	monitoringAPI.testVersion();
+    public void testMemory(){
+		monitoringAPI2.testMemory();
     }
     
     @AfterTest

--- a/src/test/java/org/craftercms/studio/test/cases/api2testcases/StatusAPI2Test.java
+++ b/src/test/java/org/craftercms/studio/test/cases/api2testcases/StatusAPI2Test.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.craftercms.studio.test.cases.apitestcases;
+package org.craftercms.studio.test.cases.api2testcases;
 
-import org.craftercms.studio.test.api.objects.MonitoringAPI;
+import org.craftercms.studio.test.api2.objects.MonitoringAPI2;
 import org.craftercms.studio.test.api.objects.SecurityAPI;
 import org.craftercms.studio.test.utils.APIConnectionManager;
 import org.craftercms.studio.test.utils.JsonTester;
@@ -28,18 +28,18 @@ import org.testng.annotations.Test;
  * Created by gustavo ortiz
  */
 
-public class StatusAPITest {
+public class StatusAPI2Test {
 
-    private MonitoringAPI monitoringAPI;
+    private MonitoringAPI2 monitoringAPI2;
     private SecurityAPI securityAPI;
     
-    public StatusAPITest(){
+    public StatusAPI2Test(){
     	APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
 				apiConnectionManager.getPort());
     	
 		securityAPI = new SecurityAPI(api, apiConnectionManager);
-    	monitoringAPI = new MonitoringAPI(api, apiConnectionManager);
+		monitoringAPI2 = new MonitoringAPI2(api, apiConnectionManager);
     }
     
     @BeforeTest
@@ -49,7 +49,7 @@ public class StatusAPITest {
 
     @Test(priority=1)
     public void testStatus(){
-    	monitoringAPI.testStatus();
+		monitoringAPI2.testStatus();
     }
     
     @AfterTest

--- a/src/test/java/org/craftercms/studio/test/cases/api2testcases/VersionAPI2Test.java
+++ b/src/test/java/org/craftercms/studio/test/cases/api2testcases/VersionAPI2Test.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.craftercms.studio.test.cases.apitestcases;
+package org.craftercms.studio.test.cases.api2testcases;
 
-import org.craftercms.studio.test.api.objects.MonitoringAPI;
+import org.craftercms.studio.test.api2.objects.MonitoringAPI2;
 import org.craftercms.studio.test.api.objects.SecurityAPI;
 import org.craftercms.studio.test.utils.APIConnectionManager;
 import org.craftercms.studio.test.utils.JsonTester;
@@ -28,18 +28,18 @@ import org.testng.annotations.Test;
  * Created by gustavo ortiz
  */
 
-public class MemoryAPITest {
+public class VersionAPI2Test {
 
-    private MonitoringAPI monitoringAPI;
+    private MonitoringAPI2 monitoringAPI2;
     private SecurityAPI securityAPI;
     
-    public MemoryAPITest(){
+    public VersionAPI2Test(){
     	APIConnectionManager apiConnectionManager = new APIConnectionManager();
 		JsonTester api = new JsonTester(apiConnectionManager.getProtocol(), apiConnectionManager.getHost(),
 				apiConnectionManager.getPort());
-    	
+		
 		securityAPI = new SecurityAPI(api, apiConnectionManager);
-    	monitoringAPI = new MonitoringAPI(api, apiConnectionManager);
+		monitoringAPI2 = new MonitoringAPI2(api, apiConnectionManager);
     }
 
     @BeforeTest
@@ -48,8 +48,8 @@ public class MemoryAPITest {
 	}
     
     @Test(priority=1)
-    public void testMemory(){
-    	monitoringAPI.testMemory();
+    public void testVersion(){
+		monitoringAPI2.testVersion();
     }
     
     @AfterTest

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/ClearConfigurationCacheAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/ClearConfigurationCacheAPITest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 public class ClearConfigurationCacheAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteTestClearConfigurationCacheAPITest";
+	private String siteId="sitetestclearconfigurationcacheapitest";
 	
 	public ClearConfigurationCacheAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/CreateSiteAPITest.java
@@ -33,7 +33,7 @@ public class CreateSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteTestCreateSiteAPITest";
+	private String siteId="sitetestcreatesiteapitest";
 
 	public CreateSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/DeleteSiteAPITest.java
@@ -34,7 +34,7 @@ public class DeleteSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteTestDeleteSiteAPITest";
+	private String siteId="sitetestdeletesiteapitest";
 	
 	public DeleteSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/ExistsSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/ExistsSiteAPITest.java
@@ -33,7 +33,7 @@ public class ExistsSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteTestExistsSiteAPITest";
+	private String siteId="sitetestexistssiteapitest";
 	
 	public ExistsSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetAuditLogAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetAuditLogAPITest.java
@@ -35,7 +35,7 @@ public class GetAuditLogAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private AuditAPI auditAPI;
-	private String siteId="siteGetAuditLogAPITest";
+	private String siteId="sitegetauditlogapitest";
 	
 	public GetAuditLogAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetConfigurationAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetConfigurationAPITest.java
@@ -33,7 +33,7 @@ public class GetConfigurationAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteGetConfigurationAPITest";
+	private String siteId="sitegetconfigurationapitest";
 	
 	
 	public GetConfigurationAPITest() {

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSiteAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSiteAPITest.java
@@ -33,7 +33,7 @@ public class GetSiteAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteGetSiteAPITest";
+	private String siteId="sitegetsiteapitest";
 	
 	public GetSiteAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSitesPerUserAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetSitesPerUserAPITest.java
@@ -33,7 +33,7 @@ public class GetSitesPerUserAPITest {
 
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
-	private String siteId="siteGetSitesPerUserAPITest";
+	private String siteId="sitegetsitesperuserapitest";
 	
 	public GetSitesPerUserAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserPermissionsAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserPermissionsAPITest.java
@@ -33,7 +33,7 @@ public class GetUserPermissionsAPITest {
 
     private SecurityAPI securityAPI;
     private SiteManagementAPI siteManagementAPI;
-    private String siteId = "getUserPermissionSiteTest";
+    private String siteId = "getuserpermissionsitetest";
     
     public GetUserPermissionsAPITest(){
     	APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserRolesAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/GetUserRolesAPITest.java
@@ -33,7 +33,7 @@ public class GetUserRolesAPITest {
 
     private SecurityAPI securityAPI;
     private SiteManagementAPI siteManagementAPI;
-    private String siteId = "getUserRolesSiteTest";
+    private String siteId = "getUserrolessitetest";
     
     public GetUserRolesAPITest(){
     	APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/RebuildDataBaseAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/RebuildDataBaseAPITest.java
@@ -34,7 +34,7 @@ public class RebuildDataBaseAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private RepoManagementAPI repoManagementAPI;
-	private String siteId="siteRebuildDataBaseAPITest";
+	private String siteId="siterebuilddatabaseapitest";
 	
 	public RebuildDataBaseAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/apitestcases/SyncFromRepoAPITest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/apitestcases/SyncFromRepoAPITest.java
@@ -34,7 +34,7 @@ public class SyncFromRepoAPITest {
 	private SecurityAPI securityAPI;
 	private SiteManagementAPI siteManagementAPI;
 	private RepoManagementAPI repoManagementAPI;
-	private String siteId="siteSyncFromRepoAPITest";
+	private String siteId="sitesyncfomrepoapitest";
 	
 	public SyncFromRepoAPITest() {
 		APIConnectionManager apiConnectionManager = new APIConnectionManager();

--- a/src/test/java/org/craftercms/studio/test/cases/generaltestcases/ChangeStateOfPreviousPublishedContent.java
+++ b/src/test/java/org/craftercms/studio/test/cases/generaltestcases/ChangeStateOfPreviousPublishedContent.java
@@ -432,7 +432,7 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 
 		// login to application with author user
 		logger.info("login to application with author user");
-		loginPage.loginToCrafter("author", "author");
+		loginPage.loginToCrafter("authorchangestate", "authorchangestate");
 
 		logger.info("Go to Preview Page");
 		this.homePage.goToPreviewPage();

--- a/src/test/java/org/craftercms/studio/test/cases/generaltestcases/Crafter3LoadTest1Script.java
+++ b/src/test/java/org/craftercms/studio/test/cases/generaltestcases/Crafter3LoadTest1Script.java
@@ -472,7 +472,6 @@ public class Crafter3LoadTest1Script extends StudioBaseTest {
 		// creating multiple content pages
 		for (int count = 0; count < 1; count++) {
 			// reload page
-			driverManager.getDriver().navigate().refresh();
 			this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath",
 					bigTree1FolderLocator);
 			this.createPageCategoryLandingPage(bigTree1FolderLocator);

--- a/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
@@ -508,14 +508,13 @@ public class PreviewPage {
 		this.driverManager.waitUntilSiteConfigMaskedModalCloses();
 		this.driverManager.waitForAnimation();
 
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
+		this.driverManager.waitUntilElementIsClickable("xpath",
 				".//div[@class='property-label label-configuration']/../input").click();
 
 		// Click on pencil icon
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath",
-						".//div[@class='property-label label-configuration']/../div[@class='options']/div")
-				.click();
+		// on chrome the div id="properties-container" over the pencil doesn't allow to click it
+		// try normal click then with js
+		this.driverManager.clickElement("cssselector", ".edit.fa-pencil");
 
 		this.driverManager.waitForAnimation();
 		this.driverManager.getDriver().switchTo().activeElement();
@@ -1848,13 +1847,13 @@ public class PreviewPage {
 				Assert.assertTrue(dependeciesItems.size() == 12);
 				break;
 			case "category-landing.ftl":
-				Assert.assertTrue(dependeciesItems.size() == 13);
+				Assert.assertTrue(dependeciesItems.size() == 12);
 				break;
 			case "home.ftl":
-				Assert.assertTrue(dependeciesItems.size() == 13);
+				Assert.assertTrue(dependeciesItems.size() == 12);
 				break;
 			case "search-results.ftl":
-				Assert.assertTrue(dependeciesItems.size() == 14);
+				Assert.assertTrue(dependeciesItems.size() == 13);
 				break;
 			default:
 				throw new IllegalArgumentException("No case for provided item name: " + componentName);

--- a/src/test/java/org/craftercms/studio/test/utils/WebDriverManager.java
+++ b/src/test/java/org/craftercms/studio/test/utils/WebDriverManager.java
@@ -613,6 +613,23 @@ public class WebDriverManager {
 
 	}
 
+	public void clickWithJS(WebElement element) {
+		((JavascriptExecutor) driver).executeScript("arguments[0].click();", element);
+	}
+
+	public void clickElement(String selectorType, String selectorValue) {
+		WebElement elementToClick = waitUntilElementIsClickable(selectorType, selectorValue);
+		try {
+			elementToClick.click();
+		} catch (WebDriverException e) {
+			if (e.getMessage().contains("is not clickable at point (")) {
+				logger.info("The element {}, {} is not clickable, clicking with JS...",
+						selectorType, selectorValue);
+				clickWithJS(elementToClick);
+			}
+		}
+	}
+
 	public void scrollUp() {
 		((JavascriptExecutor) driver).executeScript("window.scrollTo(0,0)");
 	}

--- a/src/test/resources/testng_StudioAPI.xml
+++ b/src/test/resources/testng_StudioAPI.xml
@@ -116,26 +116,6 @@
 		</classes>
 	</test>
 	
-<!--	 Monitoring -->
-	<test name="Version" preserve-order="true">
-		<classes>
-			<class
-				name="org.craftercms.studio.test.cases.apitestcases.VersionAPITest" />
-		</classes>
-	</test>
-	<test name="Status" preserve-order="true">
-		<classes>
-			<class
-				name="org.craftercms.studio.test.cases.apitestcases.StatusAPITest" />
-		</classes>
-	</test>
-	<test name="Memory" preserve-order="true">
-		<classes>
-			<class
-				name="org.craftercms.studio.test.cases.apitestcases.MemoryAPITest" />
-		</classes>
-	</test>
-	
 <!--	 Publish -->	
 	<test name="Start Publisher" preserve-order="true">
 		<classes>

--- a/src/test/resources/testng_StudioAPI2.xml
+++ b/src/test/resources/testng_StudioAPI2.xml
@@ -144,5 +144,24 @@
 			<class
 				name="org.craftercms.studio.test.cases.api2testcases.GetViewsGlobalMenuItemsForCurrentUserAPI2Test" />
 		</classes>
-	</test> 
+	</test>
+	<!--	 Monitoring -->
+	<test name="Version" preserve-order="true">
+		<classes>
+			<class
+					name="org.craftercms.studio.test.cases.api2testcases.VersionAPI2Test" />
+		</classes>
+	</test>
+	<test name="Status" preserve-order="true">
+		<classes>
+			<class
+					name="org.craftercms.studio.test.cases.api2testcases.StatusAPI2Test" />
+		</classes>
+	</test>
+	<test name="Memory" preserve-order="true">
+		<classes>
+			<class
+					name="org.craftercms.studio.test.cases.api2testcases.MemoryAPI2Test" />
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
- Move monitoring API test cases to API2
- Create a clickElement that calls clickWithJS when there is an error of `element not clickable at point (x,y)`. This happens with Chrome in the ContenType page, when we try to click the pencil icon in the Configuration config.xml
- API1 fixes. 