### PR TITLE
Feature/3290

### DIFF
--- a/src/test/java/org/craftercms/studio/test/cases/userstestcases/VerifyLanguageSettingsTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/userstestcases/VerifyLanguageSettingsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2007-2019 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.test.cases.userstestcases;
+
+import org.craftercms.studio.test.cases.StudioBaseTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class VerifyLanguageSettingsTest extends StudioBaseTest {
+
+    private String userName;
+    private String password;
+    private String defaultAdminLanguage;
+
+    @Parameters({"testUser1", "testUser2"})
+    @BeforeMethod
+    public void beforeTest(String testUser1, String testUser2) {
+        apiTestHelper.createUser(testUser1);
+        apiTestHelper.createUser(testUser2);
+        userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
+        password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
+        defaultAdminLanguage = "English";
+    }
+
+    @Parameters({"testUser1", "testUser2", "langUser1", "langUser2"})
+    @Test
+    public void verifyLanguageSettingsTest(String testUser1, String testUser2, String langUser1, String langUser2) {
+        Assert.assertEquals(loginPage.getSelectedLanguage(), defaultAdminLanguage);
+        loginPage.setLanguage(langUser1);
+        loginPage.loginToCrafter(testUser1, testUser1);
+        createSitePage.clickAdmin();
+        createSitePage.clickOnSettingsOption();
+        Assert.assertEquals(loginPage.getSelectedLanguage(), langUser1);
+        homePage.clickLogoutOutCrafter();
+
+        Assert.assertEquals(loginPage.getSelectedLanguage(), langUser1);
+        loginPage.setLanguage(langUser2);
+        loginPage.loginToCrafter(testUser2, testUser2);
+        createSitePage.clickAdmin();
+        createSitePage.clickOnSettingsOption();
+        Assert.assertEquals(loginPage.getSelectedLanguage(), langUser2);
+        homePage.clickLogoutOutCrafter();
+
+        loginPage.setLanguage(defaultAdminLanguage);
+        loginPage.loginToCrafter(userName, password);
+        createSitePage.clickAdmin();
+        createSitePage.clickOnSettingsOption();
+        Assert.assertEquals(loginPage.getSelectedLanguage(), defaultAdminLanguage);
+        homePage.clickLogoutOutCrafter();
+
+        loginPage.setUserName(testUser1);
+        Assert.assertEquals(loginPage.getSelectedLanguage(), langUser1);
+        loginPage.setUserName(testUser2);
+        Assert.assertEquals(loginPage.getSelectedLanguage(), langUser2);
+        loginPage.setUserName(userName);
+        Assert.assertEquals(loginPage.getSelectedLanguage(), defaultAdminLanguage);
+    }
+
+    @Parameters({"testUser1", "testUser2"})
+    @AfterMethod(alwaysRun = true)
+    public void afterTest(String testUser1, String testUser2) {
+        apiTestHelper.deleteSite(testUser1);
+        apiTestHelper.deleteUser(testUser2);
+    }
+}

--- a/src/test/java/org/craftercms/studio/test/pages/LoginPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/LoginPage.java
@@ -20,8 +20,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
 import org.craftercms.studio.test.utils.WebDriverManager;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
 
 /**
  *
@@ -35,6 +35,7 @@ public class LoginPage {
 	private String userNameXpath;
 	private String passwordXpath;
 	private String loginXpath;
+	private String loginLanguageSelector;
 	private static Logger logger = LogManager.getLogger(LoginPage.class);
 
 	public LoginPage(WebDriverManager driverManager,
@@ -47,6 +48,8 @@ public class LoginPage {
 		passwordXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("login.password");
 		loginXpath = UIElementsPropertiesManager.getSharedUIElementsLocators().getProperty("login.login");
+		loginLanguageSelector = UIElementsPropertiesManager.getSharedUIElementsLocators().getProperty("login.languageselector");
+
 
 	}
 	// Set user name in textbox
@@ -104,4 +107,13 @@ public class LoginPage {
 		this.driverManager = driverManager;
 	}
 
+	public void setLanguage(String lang) {
+		Select select = new Select(getDriverManager().findElement("xpath", loginLanguageSelector));
+		select.selectByVisibleText(lang);
+	}
+
+	public String getSelectedLanguage() {
+		Select select = new Select(getDriverManager().findElement("xpath", loginLanguageSelector));
+		return select.getFirstSelectedOption().getText();
+	}
 }

--- a/src/test/resources/testng_StudioUsers.xml
+++ b/src/test/resources/testng_StudioUsers.xml
@@ -58,4 +58,13 @@
 			<class name="org.craftercms.studio.test.cases.userstestcases.PaginationOfListOfUsersTest"/>
 		</classes>
 	</test>
+	<test name="Verify the language settings are persistant per browser">
+		<parameter name="testUser1" value="users0101"/>
+		<parameter name="testUser2" value="users0102"/>
+		<parameter name="langUser1" value="español"/>
+		<parameter name="langUser2" value="Deutsch"/>
+		<classes>
+			<class name="org.craftercms.studio.test.cases.userstestcases.VerifyLanguageSettingsTest"/>
+		</classes>
+	</test>
 </suite> <!-- Suite -->

--- a/src/test/resources/testng_parallel.xml
+++ b/src/test/resources/testng_parallel.xml
@@ -1001,4 +1001,13 @@
 			<class name="org.craftercms.studio.test.cases.userstestcases.PaginationOfListOfUsersTest"/>
 		</classes>
 	</test>
+	<test name="Verify the language settings are persistant per browser">
+		<parameter name="testUser1" value="users0101"/>
+		<parameter name="testUser2" value="users0102"/>
+		<parameter name="langUser1" value="español"/>
+		<parameter name="langUser2" value="Deutsch"/>
+		<classes>
+			<class name="org.craftercms.studio.test.cases.userstestcases.VerifyLanguageSettingsTest"/>
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Automated test Language settings are persisted per browser : https://github.com/craftercms/craftercms/issues/3290
 * Check for language settings per user
 * Check that when a user has a language setting previously selected then in the login page with only the username typed the language should be changed.

![language users](https://user-images.githubusercontent.com/6722074/64871388-65572780-d602-11e9-8692-679c0a71ef02.gif)
