### PR TITLE
Updates content types

### DIFF
--- a/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
+++ b/src/test/java/org/craftercms/studio/test/api/objects/SiteManagementAPI.java
@@ -44,7 +44,7 @@ public class SiteManagementAPI extends BaseAPI {
 		api.post("/studio/api/1/services/api/1/site/create.json").json(json).execute().status(HttpStatus.SC_CREATED)
 				.header("Location",
 						is(headerLocationBase + "/studio/api/1/services/api/1/site/get.json?site_id=" + siteId))
-				.json("$.message", is("OK")).debug();
+				.json("$.message", is("OK"));
 		this.setSiteId(siteId);
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/AddNewContentAndPublishContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/AddNewContentAndPublishContentTest.java
@@ -17,7 +17,6 @@
 package org.craftercms.studio.test.cases.contenttestcases;
 
 import org.craftercms.studio.test.cases.StudioBaseTest;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
 import org.testng.Assert;
@@ -43,7 +42,6 @@ public class AddNewContentAndPublishContentTest extends StudioBaseTest {
 	private String createFormArticleMainTitleElementXPath;
 	private String homeContent;
 	private String createdContentXPath;
-	private String siteDropdownListElementXPath;
 	private String categoryDrowpdownXpath;
 	private String pageTitleXpath;
 	private String pageURL;
@@ -56,7 +54,6 @@ public class AddNewContentAndPublishContentTest extends StudioBaseTest {
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
 		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
 		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -69,8 +66,6 @@ public class AddNewContentAndPublishContentTest extends StudioBaseTest {
 				.getProperty("dashboard.home_Content_Page");
 		createdContentXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.studio.deliverypagecontenttodelete");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		categoryDrowpdownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformcategorydropdown");
 		pageURL = getWebDriverManager().environmentProperties.getProperty("delivery.base.url") +

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/AddNewContentEntryTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/AddNewContentEntryTest.java
@@ -31,11 +31,6 @@ import org.testng.annotations.Test;
 
 public class AddNewContentEntryTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String testingItemRecentActivity;
 	private String randomURL;
 	private String randomInternalName;
@@ -44,81 +39,21 @@ public class AddNewContentEntryTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		testingItemRecentActivity = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitem.myrecentactivity");
 		randomURL = "Test1";
 		randomInternalName = "Testing1";
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
-
 	@Parameters({"testId"})
 	@Test()
 	public void addNewPageUsingEntryContentTypeAndContextualClickOptionTest(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(testId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(testId);
+		previewPage.clickSidebar();
 		dashboardPage.expandPagesTree();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + testId, "body" + testId);
 		dashboardPage.expandHomeTree();
-
 		Assert.assertNotNull(getWebDriverManager().waitUntilElementIsDisplayed("xpath", testingItemRecentActivity));
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteContentTest.java
@@ -31,11 +31,7 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 
 public class CopyPasteContentTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
-	private String createFormMainTitleElementXPath;
-	private String createFormSaveAndCloseElement;
 	private String copyTestItemXpath;
 	private String randomURL;
 	private String randomInternalName;
@@ -44,87 +40,31 @@ public class CopyPasteContentTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
+
 		copyTestItemXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.sitecontent.copytestitem");
-
 		randomURL = "Test1";
 		randomInternalName = "AboutUS";
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
 
 	@Parameters({"testId"})
 	@Test()
 	public void copyAndPastePageUsingContextualClickOptionsTest(String testId) {
-
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(testId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(testId);
+		previewPage.clickSidebar();
 		dashboardPage.expandPagesTree();
-
-		// create content
-		this.createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// Expand Home Tree
 		dashboardPage.expandHomeTree();
+		// create content
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + testId, "body" + testId);
 
 		// Right click and copy content.
 		dashboardPage.rightClickToCopyOptionAboutUs();
 
 		// Right click and paste content.
 		dashboardPage.rightClickToPasteOption();
-
-		// Reload page
-		getWebDriverManager().getDriver().navigate().refresh();
 
 		// Click on edit option of recent activity section
 		dashboardPage.clickOnEditOptionRecentActivity();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteContentWithSharedComponentsTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteContentWithSharedComponentsTest.java
@@ -37,10 +37,7 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:3
 public class CopyPasteContentWithSharedComponentsTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String articlesFolder;
-	private String siteDropdownElementXPath;
 	private String pasteOptionLocator;
 	private String firstChildLocator;
 	private String firstDestinationLocator;
@@ -73,12 +70,8 @@ public class CopyPasteContentWithSharedComponentsTest extends StudioBaseTest {
 		apiTestHelper.createSite(testId, "", blueprint);
 		int exitCode = this.getWebDriverManager().goToDeliveryFolderAndExecuteSiteScriptThroughCommandLine(testId, "init");
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		pasteOptionLocator = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("rightclick.paste.option");
 		firstChildLocator = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -135,13 +128,11 @@ public class CopyPasteContentWithSharedComponentsTest extends StudioBaseTest {
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
+		loginPage.loginToCrafter();
 
 		// go to preview page
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -149,22 +140,12 @@ public class CopyPasteContentWithSharedComponentsTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
 	}
 
 	public void step1() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
 		// Expand Home Tree
 		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.expandHomeTree();
@@ -279,6 +260,7 @@ public class CopyPasteContentWithSharedComponentsTest extends StudioBaseTest {
 
 		this.getWebDriverManager().waitForAnimation();
 		copyAndPasteLongTreeIntoExistentFolder(firstDestinationLocator, firstChildLocator);
+		previewPage.waitForSidebarTreeLoading(50);
 
 		String elementClassValue = "";
 		while (!(elementClassValue.contains("open"))) {

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteIntoFolderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteIntoFolderTest.java
@@ -35,11 +35,6 @@ public class CopyPasteIntoFolderTest extends StudioBaseTest {
 
 	private static final Logger logger = LogManager.getLogger(CopyPasteIntoFolderTest.class);
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String secondCopiedElementXPath;
 	private String firstCopiedElementXPath;
 	private String myRecentActivityItemsCounterXpath;
@@ -48,14 +43,6 @@ public class CopyPasteIntoFolderTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		firstCopiedElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.myrecentactivity.firstelementurl");
 		secondCopiedElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -65,82 +52,25 @@ public class CopyPasteIntoFolderTest extends StudioBaseTest {
 
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		logger.info("Changing body to not required");
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-
-	}
-
-	public void createContent() {
-		logger.info("Creating new content");
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent("Test1", "Testing1");
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-			this.getWebDriverManager().waitUntilElementIsClickable("xpath", createFormSaveAndCloseElement).click();
-
-		});
-
-	}
-
 	@Parameters({"testId"})
 	@Test()
 	public void copyAndPasteIntoFolderUsingContextualClickOptionsTest(String testId) {
 		logger.info("Starting test case");
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(testId);
-
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(testId);
+		previewPage.clickSidebar();
 		dashboardPage.expandPagesTree();
-
-		this.createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// Expand Home Tree
+		previewPage.createEntryContent("Test1", "Testing1", "title" + testId, "test" + testId);
 		dashboardPage.expandHomeTree();
-
-		// right click to see the the menu
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("foldertocopy");
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// Expand Home Tree
 		dashboardPage.rightClickToCopyComponentToNewFolder();
 
 		// paste the crafter component in the new folder created
 		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.rightClickToPasteToNewFolder();
 
-		// Copy the new content to the new folder created
-		getWebDriverManager().getDriver().navigate().refresh();
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().waitForFullExpansionOfTree();
 		dashboardPage.rightClickToCopyNewContentToNewFolder();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderPageCopyToFolderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderPageCopyToFolderTest.java
@@ -34,14 +34,8 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:34
 public class CopyPasteToFolderPageCopyToFolderTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
-	private String configurationSetUp;
 	private String dashboardLink;
 	private String recentActivityContentURL;
 	private String recentActivityContentName;
@@ -59,14 +53,6 @@ public class CopyPasteToFolderPageCopyToFolderTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		copyContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.copy.option");
@@ -87,82 +73,17 @@ public class CopyPasteToFolderPageCopyToFolderTest extends StudioBaseTest {
 				.getProperty("general.foocontent");
 		randomURL = "foo";
 		randomInternalName = "foo";
-		configurationSetUp = "<content-type name=\"/page/entry\" is-wcm-type=\"true\">"
-				+ "<label>Entry</label>" + "<form>/page/entry</form>" + "<form-path>simple</form-path>"
-				+ "<model-instance-path>NOT-USED-BY-SIMPLE-FORM-ENGINE</model-instance-path>"
-				+ "<file-extension>xml</file-extension>" + "<content-as-folder>false</content-as-folder>"
-				+ "<previewable>true</previewable>" + "<noThumbnail>true</noThumbnail>"
-				+ "<image-thumbnail>image.jpg</image-thumbnail>" + "</content-type>";
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void modifyPageXMLDefinition() {
-		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
 	}
 
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// right click to see the the menu
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(siteId);
 		logger.info("Creating new folder");
+		previewPage.clickSidebar()
+				.expandPagesTree();
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId);
 		// click on dashboard
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink);
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink).click();
@@ -185,9 +106,6 @@ public class CopyPasteToFolderPageCopyToFolderTest extends StudioBaseTest {
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.expandPagesTree();
-		
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
 		//check if the folder is opened
 		this.getWebDriverManager().waitUntilHomeIsOpened();
 	}

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderTest.java
@@ -34,11 +34,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:27
 public class CopyPasteToFolderTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
 	private String configurationSetUp;
@@ -59,14 +54,6 @@ public class CopyPasteToFolderTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		copyContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.copy.option");
@@ -96,78 +83,23 @@ public class CopyPasteToFolderTest extends StudioBaseTest {
 
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
 	}
 
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
-
 	public void setup(String siteId) {
 		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
+		loginPage.loginToCrafter();
 
 		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// modify page XML definition
+		homePage.goToDashboardPage(siteId);
+		previewPage.clickSidebar();
 		this.modifyPageXMLDefinition();
-
-		// expand pages folder
 		dashboardPage.expandPagesTree();
-
-		// right click to see the the menu
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId);
 
 		// click on dashboard
 		this.getWebDriverManager().waitForAnimation();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderWithCollisionPageTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderWithCollisionPageTest.java
@@ -34,14 +34,8 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:38
 public class CopyPasteToFolderWithCollisionPageTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
-	private String configurationSetUp;
 	private String dashboardLink;
 	private String recentActivityContentURL;
 	private String recentActivityContentName;
@@ -63,14 +57,6 @@ public class CopyPasteToFolderWithCollisionPageTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		copyContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.copy.option");
@@ -97,84 +83,21 @@ public class CopyPasteToFolderWithCollisionPageTest extends StudioBaseTest {
 				.getProperty("general.foocontent");
 		randomURL = "foo";
 		randomInternalName = "foo";
-		configurationSetUp = "<content-type name=\"/page/entry\" is-wcm-type=\"true\">"
-				+ "<label>Entry</label>" + "<form>/page/entry</form>" + "<form-path>simple</form-path>"
-				+ "<model-instance-path>NOT-USED-BY-SIMPLE-FORM-ENGINE</model-instance-path>"
-				+ "<file-extension>xml</file-extension>" + "<content-as-folder>false</content-as-folder>"
-				+ "<previewable>true</previewable>" + "<noThumbnail>true</noThumbnail>"
-				+ "<image-thumbnail>image.jpg</image-thumbnail>" + "</content-type>";
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void modifyPageXMLDefinition() {
-		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
 	}
 
 	public void loginAndChangeContentTypeConfiguration(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(siteId);
+		previewPage.clickSidebar()
+				.expandPagesTree();
 
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
 	}
 
 	public void createContentAndFolder() {
-
-		// right click to see the the menu
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		//getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title", "body");
 		getWebDriverManager().waitUntilSidebarOpens();
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderWithCollisionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CopyPasteToFolderWithCollisionTest.java
@@ -34,11 +34,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:31
 public class CopyPasteToFolderWithCollisionTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
 	private String configurationSetUp;
@@ -63,14 +58,6 @@ public class CopyPasteToFolderWithCollisionTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		copyContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.copy.option");
@@ -106,78 +93,26 @@ public class CopyPasteToFolderWithCollisionTest extends StudioBaseTest {
 
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
 
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
 	}
 
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
 
 	public void loginAndChangeContentTypeConfiguration(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(siteId);
+		previewPage.clickSidebar();
 		// modify page XML definition
 		this.modifyPageXMLDefinition();
+		previewPage.expandPagesTree();
 	}
 
 	public void createContentAndFolder() {
-
-		// right click to see the the menu
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title", "body");
 	}
 
 	public void goToDashboardAndManageContents() {

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CutPasteToFolderPageMoveToFolderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CutPasteToFolderPageMoveToFolderTest.java
@@ -36,14 +36,8 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:34
 public class CutPasteToFolderPageMoveToFolderTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
-	private String configurationSetUp;
 	private String dashboardLink;
 	private String recentActivityContentURL;
 	private String recentActivityContentName;
@@ -61,14 +55,6 @@ public class CutPasteToFolderPageMoveToFolderTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		cutContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.cut.option");
@@ -89,82 +75,19 @@ public class CutPasteToFolderPageMoveToFolderTest extends StudioBaseTest {
 				.getProperty("dashboard.myrecentactivity.selectall");
 		randomURL = "foo";
 		randomInternalName = "foo";
-		configurationSetUp = "<content-type name=\"/page/entry\" is-wcm-type=\"true\">"
-				+ "<label>Entry</label>" + "<form>/page/entry</form>" + "<form-path>simple</form-path>"
-				+ "<model-instance-path>NOT-USED-BY-SIMPLE-FORM-ENGINE</model-instance-path>"
-				+ "<file-extension>xml</file-extension>" + "<content-as-folder>false</content-as-folder>"
-				+ "<previewable>true</previewable>" + "<noThumbnail>true</noThumbnail>"
-				+ "<image-thumbnail>image.jpg</image-thumbnail>" + "</content-type>";
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void modifyPageXMLDefinition() {
-		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
 	}
 
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// right click to see the the menu
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(siteId);
+		previewPage.clickSidebar();
+		previewPage.expandPagesTree();
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId);
 
 		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
 		// click on dashboard
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink);
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink).click();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CutPasteToFolderTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/CutPasteToFolderTest.java
@@ -34,11 +34,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:27
 public class CutPasteToFolderTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
 	private String configurationSetUp;
@@ -56,14 +51,6 @@ public class CutPasteToFolderTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		cutContent = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("rightclick.cut.option");
@@ -87,78 +74,21 @@ public class CutPasteToFolderTest extends StudioBaseTest {
 
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
 	}
 
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
-
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// modify page XML definition
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(siteId);
+		previewPage.clickSidebar();
 		this.modifyPageXMLDefinition();
-
-		// expand pages folder
 		dashboardPage.expandPagesTree();
-
-		// right click to see the the menu
 		logger.info("Creating new folder");
 		dashboardPage.rightClickNewFolderOnHome();
-
-		// Set the name of the folder
 		dashboardPage.setFolderName("a-folder");
 
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId);
 
 		// click on dashboard
 		this.getWebDriverManager().waitForAnimation();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DeleteContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DeleteContentTest.java
@@ -35,102 +35,30 @@ import org.testng.annotations.Test;
 public class DeleteContentTest extends StudioBaseTest {
 
 	private static final Logger logger = LogManager.getLogger(DeleteContentTest.class);
-
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormMainTitleElementXPath;
-	private String createFormSaveAndCloseElement;
 	private String testingItemURLXpath;
 
 	@Parameters({"testId", "blueprint"})
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		testingItemURLXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.myrecentactivity.firstelementurl");
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-
-	}
-
-	public void createContent() {
-		logger.info("Creating new content");
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent("Test1", "Testing1");
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement).click();
-		});
-
 	}
 
 	@Parameters({"testId"})
 	@Test()
 	public void deletePageUsingContextualClickDeleteOptionTest(String testId) {
 		logger.info("Starting test case");
-		loginPage.loginToCrafter(userName, password);
-		
-		//Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(testId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(testId);
+		previewPage.clickSidebar();
 		getWebDriverManager().waitUntilSidebarOpens();
-
-		// expand pages folder
 		dashboardPage.expandPagesTree();
-
-		// create content
-
-		createContent();
-
+		previewPage.createEntryContent("Test1", "Testing1", "title", "body");
 		getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
 		dashboardPage.expandHomeTree();
-
-		// right click to delete
-
 		dashboardPage.rightClickToDeleteContent();
-
-		// confirmation
-
 		dashboardPage.clicktoDeleteContent();
-
-		// submittal complete ok
 		dashboardPage.clickOKSubmittalComplete();
 
 		this.getWebDriverManager().waitForAnimation();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DependenciesCalculationItemRefersToTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DependenciesCalculationItemRefersToTest.java
@@ -37,10 +37,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:5
 public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
-	private String siteDropdownListElementXPath;
 	private String generalEditOption;
 	private String dependenciesMenuOption;
 	private String styleLocator;
@@ -94,17 +90,11 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		initLocatorsFirstPart();
 		initLocatorsSecondPart();
 	}
 
 	public void initLocatorsFirstPart() {
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		generalEditOption = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.edittopnavoption");
 		dependenciesMenuOption = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -140,7 +130,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 				.getProperty("general.components.header");
 		featuresFolderXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.components.featuresfolder");
-		fourXpath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.components.four");
+		fourXpath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.components.five");
 		leftrailsfolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.components.leftrailsfolder");
 		wommenStylesArticlePage = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -202,22 +192,10 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		// go to preview page
 		homePage.goToPreviewPage(siteId);
-
-		if (this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", siteDropdownElementXPath)
-				.isDisplayed())
-			if (!(this.getWebDriverManager().waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
-					.getAttribute("class").contains("site-dropdown-open")))
-				this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", siteDropdownElementXPath)
-						.click();
-			else
-				throw new NoSuchElementException(
-						"Site creation process is taking too long time and the element was not found");
+		previewPage.clickSidebar();
 	}
 
 	public void step1() {
@@ -233,7 +211,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForPageItem("Home", true);
+		previewPage.checkDependenciesForPageItem("Home", false);
 	}
 
 	public void step2() {
@@ -252,7 +230,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForPageItem("Style",true);
+		previewPage.checkDependenciesForPageItem("Style",false);
 	}
 
 	public void step3() {
@@ -282,7 +260,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForPageItem("Women Styles for Winter",true);
+		previewPage.checkDependenciesForPageItem("Women Styles for Winter",false);
 	}
 
 	public void step4() {
@@ -307,7 +285,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForPageItem("Testing1",true);
+		previewPage.checkDependenciesForPageItem("Testing1",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
@@ -331,7 +309,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForPageItem("Search Results",true);
+		previewPage.checkDependenciesForPageItem("Search Results",false);
 	}
 
 	public void step6() {
@@ -352,7 +330,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Latest Articles Widget",true);
+		previewPage.checkDependenciesForComponentItem("Latest Articles Widget",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesWidgetFolder);
@@ -370,7 +348,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Header",true);
+		previewPage.checkDependenciesForComponentItem("Header",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", headerFolderXpath);
@@ -387,7 +365,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Four",true);
+		previewPage.checkDependenciesForComponentItem("Five",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", featuresFolderXpath);
@@ -437,7 +415,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("book-woman-pic.jpg",true);
+		previewPage.checkNoDependenciesForItem("book-woman-pic.jpg",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", staticAssetsimagesFolder);
@@ -484,7 +462,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("category-landing.ftl",true);
+		previewPage.checkDependenciesForTemplateItem("category-landing.ftl",false);
 
 	}
 
@@ -495,7 +473,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("home.ftl",true);
+		previewPage.checkDependenciesForTemplateItem("home.ftl",false);
 	}
 
 	public void step14() {
@@ -505,7 +483,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("search-results.ftl",true);
+		previewPage.checkDependenciesForTemplateItem("search-results.ftl",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", templatesPagesFolder);
@@ -541,7 +519,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("category-landing.groovy",true);
+		previewPage.checkNoDependenciesForItem("category-landing.groovy",false);
 	}
 
 	public void step16() {
@@ -551,7 +529,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("home.groovy",true);
+		previewPage.checkNoDependenciesForItem("home.groovy",false);
 	}
 
 	public void step17() {
@@ -561,7 +539,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("search-results.groovy",true);
+		previewPage.checkNoDependenciesForItem("search-results.groovy",false);
 	}
 
 	public void step18() {
@@ -571,7 +549,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("site-map.groovy",true);
+		previewPage.checkNoDependenciesForItem("site-map.groovy",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", scriptsPagesFolderXpath);
@@ -609,7 +587,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("font-awesome.min.css",true);
+		previewPage.checkNoDependenciesForItem("font-awesome.min.css",false);
 	}
 
 	public void step20() {
@@ -619,7 +597,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("ie8.css",true);
+		previewPage.checkNoDependenciesForItem("ie8.css",false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", staticAssetsCssFolder);
@@ -636,7 +614,7 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("jquery.min.js",true);
+		previewPage.checkNoDependenciesForItem("jquery.min.js",false);
 	}
 
 	public void rightClickAndClickOnDependencies(String itemLocator, String menuLocation) {
@@ -653,17 +631,12 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 	}
 
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
-	}
-
 	public void createNewPageArticle(String folderLocation) {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
@@ -672,9 +645,6 @@ public class DependenciesCalculationItemRefersToTest extends StudioBaseTest {
 	@Test()
 	public void verifyDependencyCalculationForWhatAnItemRefersTo(String testId) {
 		loginAndGoToPreview(testId);
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		// expand pages folder

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DependenciesCalculationRefersToAnItemTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/DependenciesCalculationRefersToAnItemTest.java
@@ -37,10 +37,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:4
 public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
-	private String siteDropdownListElementXPath;
 	private String generalEditOption;
 	private String dependenciesMenuOption;
 	private String styleLocator;
@@ -59,7 +55,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 	private String headerFolderXpath;
 	private String headerXpath;
 	private String featuresFolderXpath;
-	private String fourXpath;
+	private String fiveXpath;
 	private String leftrailsfolder;
 	private String wommenStylesArticlePage;
 	private String leftrailwithlastestarticles;
@@ -94,17 +90,11 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		initLocatorsFirstPart();
 		initLocatorsSecondPart();
 	}
 
 	public void initLocatorsFirstPart() {
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		generalEditOption = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.edittopnavoption");
 		dependenciesMenuOption = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -140,7 +130,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 				.getProperty("general.components.header");
 		featuresFolderXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.components.featuresfolder");
-		fourXpath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.components.four");
+		fiveXpath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.components.five");
 		leftrailsfolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.components.leftrailsfolder");
 		wommenStylesArticlePage = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -202,22 +192,9 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		if (this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", siteDropdownElementXPath)
-				.isDisplayed())
-			if (!(this.getWebDriverManager().waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
-					.getAttribute("class").contains("site-dropdown-open")))
-				this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", siteDropdownElementXPath)
-						.click();
-			else
-				throw new NoSuchElementException(
-						"Site creation process is taking too long time and the element was not found");
+		previewPage.clickSidebar();
 	}
 
 	public void step1() {
@@ -233,7 +210,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Home",false);
+		previewPage.checkNoDependenciesForItem("Home",true);
 	}
 
 	public void step2() {
@@ -252,7 +229,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Style",false);
+		previewPage.checkNoDependenciesForItem("Style",true);
 	}
 
 	public void step3() {
@@ -282,7 +259,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Women Styles for Winter",false);
+		previewPage.checkNoDependenciesForItem("Women Styles for Winter",true);
 	}
 
 	public void step4() {
@@ -307,7 +284,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Testing1",false);
+		previewPage.checkNoDependenciesForItem("Testing1",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
@@ -331,7 +308,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Search Results",false);
+		previewPage.checkNoDependenciesForItem("Search Results",true);
 	}
 
 	public void step6() {
@@ -352,7 +329,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Latest Articles Widget",false);
+		previewPage.checkDependenciesForComponentItem("Latest Articles Widget",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesWidgetFolder);
@@ -370,7 +347,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Header",false);
+		previewPage.checkDependenciesForComponentItem("Header",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", headerFolderXpath);
@@ -383,11 +360,11 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().scrollDownIntoSideBar();
-		this.rightClickAndClickOnDependencies(fourXpath, "Components");
+		this.rightClickAndClickOnDependencies(fiveXpath, "Components");
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("Four",false);
+		previewPage.checkNoDependenciesForItem("Five",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", featuresFolderXpath);
@@ -404,7 +381,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForComponentItem("Left Rail with Latest Articles",false);
+		previewPage.checkDependenciesForComponentItem("Left Rail with Latest Articles",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", leftrailsfolder);
@@ -437,7 +414,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForStaticAssetItem("book-woman-pic.jpg",false, false);
+		previewPage.checkDependenciesForStaticAssetItem("book-woman-pic.jpg",true, false);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", staticAssetsimagesFolder);
@@ -473,7 +450,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("article.ftl",false);
+		previewPage.checkDependenciesForTemplateItem("article.ftl",true);
 
 	}
 
@@ -484,7 +461,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("category-landing.ftl",false);
+		previewPage.checkDependenciesForTemplateItem("category-landing.ftl",true);
 
 	}
 
@@ -495,7 +472,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("home.ftl",false);
+		previewPage.checkDependenciesForTemplateItem("home.ftl",true);
 	}
 
 	public void step14() {
@@ -505,7 +482,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForTemplateItem("search-results.ftl",false);
+		previewPage.checkDependenciesForTemplateItem("search-results.ftl",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", templatesPagesFolder);
@@ -541,7 +518,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesFoScriptItem("category-landing.groovy",false);
+		previewPage.checkDependenciesFoScriptItem("category-landing.groovy",true);
 	}
 
 	public void step16() {
@@ -551,7 +528,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesFoScriptItem("home.groovy",false);
+		previewPage.checkDependenciesFoScriptItem("home.groovy",true);
 	}
 
 	public void step17() {
@@ -561,7 +538,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesFoScriptItem("search-results.groovy",false);
+		previewPage.checkDependenciesFoScriptItem("search-results.groovy",true);
 	}
 
 	public void step18() {
@@ -571,7 +548,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("site-map.groovy",false);
+		previewPage.checkNoDependenciesForItem("site-map.groovy",true);
 
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", scriptsPagesFolderXpath);
@@ -608,7 +585,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkNoDependenciesForItem("font-awesome.min.css",false);
+		previewPage.checkNoDependenciesForItem("font-awesome.min.css",true);
 	}
 
 	public void step20() {
@@ -635,7 +612,7 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForStaticAssetItem("jquery.min.js",false, false);
+		previewPage.checkDependenciesForStaticAssetItem("jquery.min.js",true, false);
 	}
 
 	public void rightClickAndClickOnDependencies(String itemLocator, String menuLocation) {
@@ -653,17 +630,12 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 	}
 
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
-	}
-
 	public void createNewPageArticle(String folderLocation) {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
@@ -672,9 +644,6 @@ public class DependenciesCalculationRefersToAnItemTest extends StudioBaseTest {
 	@Test()
 	public void verifyDependencyCalculationForWhatRefersToAnItem(String testId) {
 		loginAndGoToPreview(testId);
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		// expand pages folder

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/EditContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/EditContentTest.java
@@ -31,11 +31,7 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 
 public class EditContentTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
-	private String createFormMainTitleElementXPath;
-	private String createFormSaveAndCloseElement;
 	private String myRecentActivityTestingItem;
 	private String randomURL;
 	private String randomInternalName;
@@ -44,52 +40,13 @@ public class EditContentTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
 		myRecentActivityTestingItem = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitemedited.myrecentactivity");
 
 		randomURL = "Test1";
 		randomInternalName = "Testing1";
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createNewContent() {
-		// right click to see the the menu
-
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
 
 	public void editingContentRecentlyCreated() {
@@ -108,33 +65,14 @@ public class EditContentTest extends StudioBaseTest {
 	@Parameters({"testId"})
 	@Test()
 	public void verifyTheEditionOfAPageUsingRightClickEditOptionTest(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage(testId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
+		loginPage.loginToCrafter();
+		homePage.goToDashboardPage(testId);
+		previewPage.clickSidebar();
 		dashboardPage.expandPagesTree();
-
-		// create new content
-		createNewContent();
-
-		// Expand Home Tree
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + testId, "body" + testId);
 		dashboardPage.expandHomeTree();
 
-		// Edited content recently created
-		getWebDriverManager().getDriver().navigate().refresh();
-
 		editingContentRecentlyCreated();
-
 		Assert.assertNotNull(getWebDriverManager().waitUntilElementIsDisplayed("xpath", myRecentActivityTestingItem),
 				"Content page is not displayed on the My Recent Activity Widget");
 	}

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameRenameThenPublishPageRenameTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameRenameThenPublishPageRenameTest.java
@@ -37,8 +37,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:43
 public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
 	private String dashboardLink;
@@ -65,7 +63,6 @@ public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 	private String recentlyPublishedContentName;
 	private String recentlyPublishedContentURL;
 	private String recentlyPublishedSelectAll;
-	private String siteDropDownXpath;
 	private int numberOfAttemptsForElementsDisplayed;
 	private static Logger logger = LogManager.getLogger(FileRenameRenameThenPublishPageRenameTest.class);
 
@@ -75,8 +72,6 @@ public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 		apiTestHelper.createSite(testId, "", blueprint);
 		int exitCode = this.getWebDriverManager().goToDeliveryFolderAndExecuteSiteScriptThroughCommandLine(testId, "init");
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -127,48 +122,24 @@ public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 				.getProperty("dashboard.myrecentactivity.itemurl");
 		recentlyActivityItemConfigurationEditedIcon = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.myrecentactivity.itemconfigurationeditedicon");
-		siteDropDownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("foo", "foo", "foo", folderLocation,
-				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo");
+				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo", "foo");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
 	}
 
 	public void setup(String testId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-		getWebDriverManager().clickElement("xpath", siteDropDownXpath);
+		previewPage.clickSidebar();
 		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// body not required
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.expandHomeTree();
 
 		// expand Articles folder
@@ -403,25 +374,6 @@ public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 	}
 
-	public void step13() {
-		for (int i = 0; i < numberOfAttemptsForElementsDisplayed; i++) {
-			try {
-				this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", fooContentXpath)
-						.click();
-				this.getWebDriverManager().waitUntilAttributeContains("xpath", topNavStatusIcon, "class", "undefined live");
-				break;
-			} catch (TimeoutException e) {
-				this.getWebDriverManager().takeScreenshot("PageNotPublishedOnTopNavBar");
-				logger.warn("Content page is not published yet, checking again if it has published icon on top bar");
-				getWebDriverManager().getDriver().navigate().refresh();
-			}
-		}
-
-		String elementClassValue = this.getWebDriverManager().getDriver().findElement(By.xpath(topNavStatusIcon))
-				.getAttribute("class");
-		Assert.assertTrue(elementClassValue.contains("undefined live"));
-	}
-
 	public void step11() {
 		// steps 11, , 12, 13 and 14
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", fooContentXpath);
@@ -550,7 +502,5 @@ public class FileRenameRenameThenPublishPageRenameTest extends StudioBaseTest {
 		this.step19();
 		// Step 20
 		this.step20();
-
 	}
-
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameRenameThenPublishTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameRenameThenPublishTest.java
@@ -38,8 +38,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:42
 public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
 	private String configurationSetUp;
@@ -67,7 +65,6 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 	private String recentlyPublishedContentName;
 	private String recentlyPublishedContentURL;
 	private String recentlyPublishedSelectAll;
-	private String siteDropDownXpath;
 	private int numberOfAttemptsForElementsDisplayed;
 	private static Logger logger = LogManager.getLogger(FileRenameRenameThenPublishTest.class);
 
@@ -77,8 +74,6 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 		apiTestHelper.createSite(testId, "", blueprint);
 		int exitCode = this.getWebDriverManager().goToDeliveryFolderAndExecuteSiteScriptThroughCommandLine(testId, "init");
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -134,8 +129,6 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 		recentlyActivityItemConfigurationEditedIcon = uiElementsPropertiesManager
 				.getSharedUIElementsLocators()
 				.getProperty("dashboard.myrecentactivity.itemconfigurationeditedicon");
-		siteDropDownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
 		configurationSetUp = "<content-type name=\"/page/article\" is-wcm-type=\"true\">"
@@ -149,9 +142,6 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 				+ "</content-type>";
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
 
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderForPageArticle(configurationSetUp);
@@ -161,29 +151,15 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("foo", "foo", "foo", folderLocation,
-				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo");
+				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo", "foo");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
 
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
-	}
-
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropDownXpath);
-
-		// body not required
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
+		previewPage.clickSidebar();
 		// modify page XML definition
 		this.modifyPageXMLDefinition();
 
@@ -206,8 +182,6 @@ public class FileRenameRenameThenPublishTest extends StudioBaseTest {
 		this.createNewPageArticle(
 				folder2016Locator + "/../../../../../div[@class='ygtvchildren']//span[text()='12']");
 
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
 		getWebDriverManager().waitUntilHomeIsOpened();
 		Assert.assertTrue(this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", fooContentXpath)

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameThenPublishPageRenameTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameThenPublishPageRenameTest.java
@@ -38,8 +38,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:41,45
 public class FileRenameThenPublishPageRenameTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
 	private String dashboardLink;
@@ -63,7 +61,6 @@ public class FileRenameThenPublishPageRenameTest extends StudioBaseTest {
 	private String recentlyActivityItemIcon;
 	private String recentlyActivityItemURL;
 	private String recentlyActivityItemConfigurationEditedIcon;
-	private String siteDropDownXpath;
 	private int numberOfAttemptsForElementsDisplayed;
 	private static Logger logger = LogManager.getLogger(FileRenameThenPublishPageRenameTest.class);
 
@@ -73,8 +70,6 @@ public class FileRenameThenPublishPageRenameTest extends StudioBaseTest {
 		apiTestHelper.createSite(testId, "", blueprint);
 		int exitCode = this.getWebDriverManager().goToDeliveryFolderAndExecuteSiteScriptThroughCommandLine(testId, "init");
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -119,49 +114,24 @@ public class FileRenameThenPublishPageRenameTest extends StudioBaseTest {
 				.getProperty("dashboard.myrecentactivity.itemurl");
 		recentlyActivityItemConfigurationEditedIcon = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.myrecentactivity.itemconfigurationeditedicon");
-		siteDropDownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
 
 	public void createNewPageArticle(String folderLocation) {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("foo", "foo", "foo", folderLocation,
-				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo");
+				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo", "section");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
 	}
 
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropDownXpath);
-
-		getWebDriverManager().waitUntilSidebarOpens();
-
-		// body not required
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		this.getWebDriverManager().waitForAnimation();
+		previewPage.clickSidebar();
 		dashboardPage.expandHomeTree();
 
 		// expand Articles folder

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameThenPublishTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/FileRenameThenPublishTest.java
@@ -38,8 +38,6 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:40, 44
 public class FileRenameThenPublishTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
 	private String configurationSetUp;
@@ -64,7 +62,6 @@ public class FileRenameThenPublishTest extends StudioBaseTest {
 	private String recentlyActivityItemIcon;
 	private String recentlyActivityItemURL;
 	private String recentlyActivityItemConfigurationEditedIcon;
-	private String siteDropDownXpath;
 	private int numberOfAttemptsForElementsDisplayed;
 	private static Logger logger = LogManager.getLogger(FileRenameThenPublishTest.class);
 
@@ -74,8 +71,6 @@ public class FileRenameThenPublishTest extends StudioBaseTest {
 		apiTestHelper.createSite(testId, "", blueprint);
 		int exitCode = this.getWebDriverManager().goToDeliveryFolderAndExecuteSiteScriptThroughCommandLine(testId, "init");
 		Assert.assertEquals(exitCode, 0, "Init site process failed");
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -120,8 +115,6 @@ public class FileRenameThenPublishTest extends StudioBaseTest {
 				.getProperty("dashboard.myrecentactivity.itemurl");
 		recentlyActivityItemConfigurationEditedIcon = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.myrecentactivity.itemconfigurationeditedicon");
-		siteDropDownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
 		configurationSetUp = "<content-type name=\"/page/article\" is-wcm-type=\"true\">"
@@ -135,10 +128,6 @@ public class FileRenameThenPublishTest extends StudioBaseTest {
 				+ "</content-type>";
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderForPageArticle(configurationSetUp);
 	}
@@ -147,35 +136,17 @@ public class FileRenameThenPublishTest extends StudioBaseTest {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("foo", "foo", "foo", folderLocation,
-				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo");
+				selectEntertaimentCategoryCheckBox, selectAllSegmentsCheckBox, "foo", "foo", "foo", "foo");
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-		previewPage.changeDateOfArticlePageToNotRequired();
 	}
 
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropDownXpath);
-
-		// body not required
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		// modify page XML definition
+		previewPage.clickSidebar();
 		this.modifyPageXMLDefinition();
-
 		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
 		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.expandHomeTree();
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/RenameViaFormPageMoveNameRenameTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/RenameViaFormPageMoveNameRenameTest.java
@@ -32,14 +32,10 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:33
 public class RenameViaFormPageMoveNameRenameTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
-	private String configurationSetUp;
 	private String dashboardLink;
 	private String editRecentlyContentCreated;
 	private String recentActivityContentURL;
@@ -54,14 +50,10 @@ public class RenameViaFormPageMoveNameRenameTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		editRecentlyContentCreated = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -79,72 +71,15 @@ public class RenameViaFormPageMoveNameRenameTest extends StudioBaseTest {
 		filenameInput = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("frame1.filenameinput");
 		randomURL = "foo";
 		randomInternalName = "foo";
-		configurationSetUp = "<content-type name=\"/page/entry\" is-wcm-type=\"true\">"
-				+ "<label>Entry</label>" + "<form>/page/entry</form>" + "<form-path>simple</form-path>"
-				+ "<model-instance-path>NOT-USED-BY-SIMPLE-FORM-ENGINE</model-instance-path>"
-				+ "<file-extension>xml</file-extension>" + "<content-as-folder>false</content-as-folder>"
-				+ "<previewable>true</previewable>" + "<noThumbnail>true</noThumbnail>"
-				+ "<image-thumbnail>image.jpg</image-thumbnail>" + "</content-type>";
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
 
 	}
 
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// create content
-		createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// click on dashboard
-		this.getWebDriverManager().waitForAnimation();
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink);
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink).click();
+		previewPage.clickSidebar();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId)
+				.goToDashboard();
 
 		// check items on My Recent Activity widget
 		this.getWebDriverManager().waitForAnimation();
@@ -162,16 +97,8 @@ public class RenameViaFormPageMoveNameRenameTest extends StudioBaseTest {
 	}
 
 	public void step2() {
-		// expand pages folder
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		this.getWebDriverManager().waitForAnimation();
 		dashboardPage.expandPagesTree();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// expand home
-		dashboardPage.expandHomeTree();
+		//dashboardPage.expandHomeTree();
 	}
 
 	public void step9() {

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/RenameViaFormTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/RenameViaFormTest.java
@@ -32,11 +32,8 @@ import org.testng.annotations.Test;
 // Test Case Studio- Site Content ID:26
 public class RenameViaFormTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String createFormFrameElementCss;
 	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String randomURL;
 	private String randomInternalName;
 	private String configurationSetUp;
@@ -54,14 +51,10 @@ public class RenameViaFormTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.dashboard.dashboardlink");
 		editRecentlyContentCreated = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -91,75 +84,16 @@ public class RenameViaFormTest extends StudioBaseTest {
 
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
 	public void modifyPageXMLDefinition() {
 		previewPage.modifyPageXMLDefinitionContentAsFolderEntryContentType(configurationSetUp);
 	}
 
-	public void createContent() {
-		// right click to see the the menu
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent(randomURL, randomInternalName);
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager()
-					.driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
-
 	public void setup(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// modify page XML definition
+		previewPage.clickSidebar();
 		this.modifyPageXMLDefinition();
-
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		// create content
-		createContent();
-
-		// reload page
-		//getWebDriverManager().getDriver().navigate().refresh();
-
-		// click on dashboard
-		this.getWebDriverManager().waitForAnimation();
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink);
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", dashboardLink)
-				.click();
+		previewPage.createEntryContent(randomURL, randomInternalName, "title" + siteId, "body" + siteId);
 
 		// check items on My Recent Activity widget
 		this.getWebDriverManager().waitForAnimation();
@@ -177,15 +111,6 @@ public class RenameViaFormTest extends StudioBaseTest {
 	}
 
 	public void step3() {
-		// expand pages folder
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		this.getWebDriverManager().waitForAnimation();
-		dashboardPage.expandPagesTree();
-
-		// reload page
-		//getWebDriverManager().getDriver().navigate().refresh();
-
-		// expand home
 		dashboardPage.expandHomeTree();
 	}
 
@@ -278,6 +203,6 @@ public class RenameViaFormTest extends StudioBaseTest {
 	@Parameters({"testId"})
 	@AfterMethod(alwaysRun = true)
 	public void afterTest(String testId) {
-		//apiTestHelper.deleteSite(testId);
+		apiTestHelper.deleteSite(testId);
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTest.java
@@ -38,9 +38,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:6
 public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String articles2016Folder;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
@@ -72,10 +69,6 @@ public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTes
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.articles.2016folder");
 		selectAllSegmentsCheckBox = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -125,14 +118,10 @@ public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTes
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		// go to preview page
 		homePage.goToPreviewPage(siteId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar();
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
@@ -142,7 +131,7 @@ public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTes
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void createSecondPageArticle(String folderLocation) {
@@ -150,18 +139,10 @@ public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTes
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingWinterWomanPicture("test2", "Testing2", "test2",
 				folderLocation, selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject",
-				"ArticleAuthor", "ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleAuthor", "ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		// expand pages folder
 		dashboardPage.expandPagesTree();
@@ -301,7 +282,7 @@ public class VerifyThatCopyOperationHandlesDependenciesAndComponentsCorrectlyTes
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForStaticAssetItem("winter-woman-pic.jpg", false, false);
+		previewPage.checkDependenciesForStaticAssetItem("winter-woman-pic.jpg", true, false);
 
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrectlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrectlyTest.java
@@ -39,8 +39,6 @@ import org.openqa.selenium.WebElement;
 public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrectlyTest
 		extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String siteDropdownElementXPath;
 	private String articles2016Folder;
 	private String selectAllSegmentsCheckBox;
@@ -78,8 +76,6 @@ public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrect
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.sitedropdown");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -141,13 +137,8 @@ public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrect
 	}
 
 	public void loginAndGoToPreview(String testId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
 		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
 		this.getWebDriverManager().waitUntilSidebarOpens();
 	}
@@ -157,7 +148,7 @@ public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrect
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingUploadedImage("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void createSecondPageArticle(String folderLocation) {
@@ -165,19 +156,11 @@ public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrect
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentUsingWinterWomanPicture("test2", "Testing2", "test2",
 				folderLocation, selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject",
-				"ArticleAuthor", "ArticleSummary");
+				"ArticleAuthor", "ArticleSummary", "ArticleSection");
 	}
 
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
 		// expand pages folder
 		dashboardPage.expandPagesTree();
 
@@ -400,7 +383,7 @@ public class VerifyThatDuplicateOperationHandlesDependenciesAndComponentsCorrect
 
 		// check dependencies are listed
 		logger.info("Check Listed Dependencies");
-		previewPage.checkDependenciesForStaticAssetItem("duplication-winter-woman-pic.jpg", false, true);
+		previewPage.checkDependenciesForStaticAssetItem("duplication-winter-woman-pic.jpg", true, true);
 
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatSaveDraftWorksProperlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatSaveDraftWorksProperlyTest.java
@@ -35,10 +35,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:48
 public class VerifyThatSaveDraftWorksProperlyTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
-	private String siteDropdownListElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -56,12 +52,6 @@ public class VerifyThatSaveDraftWorksProperlyTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -85,13 +75,10 @@ public class VerifyThatSaveDraftWorksProperlyTest extends StudioBaseTest {
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		// go to preview page
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar();
 
 	}
 
@@ -100,18 +87,12 @@ public class VerifyThatSaveDraftWorksProperlyTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentAsDraft("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticleAsDraft() {
 
 		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
 		this.getWebDriverManager().waitUntilSidebarOpens();
 
 		// Expand Home Tree
@@ -161,13 +142,9 @@ public class VerifyThatSaveDraftWorksProperlyTest extends StudioBaseTest {
 				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", testingArticleCompleteXPath)
 				.isDisplayed());
 		logger.info("Checking if testing article has locked icon");
-		Assert.assertTrue(this.getWebDriverManager()
-				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath",
-						testingArticleCompleteXPath + "//span[@class='fa studio-fa-stack-1x fa-lock locked']")
-				.isDisplayed());
-		this.getWebDriverManager()
-				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", testingArticleCompleteXPath)
-				.click();
+
+		this.getWebDriverManager().clickElement("xpath", testingArticleCompleteXPath);
+
 
 		this.getWebDriverManager().waitForFullExpansionOfTree();
 		getWebDriverManager().getDriver().switchTo().defaultContent();

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioAllowsToPublishAContentProperlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioAllowsToPublishAContentProperlyTest.java
@@ -37,9 +37,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:23
 public class VerifyThatStudioAllowsToPublishAContentProperlyTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -57,10 +54,6 @@ public class VerifyThatStudioAllowsToPublishAContentProperlyTest extends StudioB
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -82,13 +75,10 @@ public class VerifyThatStudioAllowsToPublishAContentProperlyTest extends StudioB
 	}
 
 	public void loginAndGoToPreview(String testId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -96,23 +86,10 @@ public class VerifyThatStudioAllowsToPublishAContentProperlyTest extends StudioB
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioAllowsToUnlockAContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioAllowsToUnlockAContentTest.java
@@ -35,9 +35,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:22
 public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -53,10 +50,6 @@ public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -76,17 +69,10 @@ public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void unlockArticle() {
@@ -108,7 +94,6 @@ public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 
 	public void checkLockedIcon() {
 		logger.info("Checking if testing article is locked");
-		this.getWebDriverManager().waitUntilSidebarOpens();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath",
 				testingArticleCompleteXPath);
 		Assert.assertTrue(this.getWebDriverManager()
@@ -122,15 +107,6 @@ public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);
@@ -149,7 +125,7 @@ public class VerifyThatStudioAllowsToUnlockAContentTest extends StudioBaseTest {
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentAsDraft("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 	}
 
 	@Parameters({"testId"})

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest.java
@@ -34,9 +34,6 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 // Test Case Studio- Site Content ID:21
 public class VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -52,10 +49,6 @@ public class VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest extends Stu
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -75,17 +68,10 @@ public class VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest extends Stu
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void checkUnlockOptionOnContextClick() {
@@ -127,15 +113,6 @@ public class VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest extends Stu
 	}
 	
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);
@@ -154,7 +131,7 @@ public class VerifyThatStudioDisplaysAsLockedTheContentCorrectlyTest extends Stu
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContentAsDraft("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
+				"ArticleSummary", "ArticleSection");
 	}
 
 	@Parameters({"testId"})

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest.java
@@ -38,9 +38,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:10
 public class VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -59,10 +56,6 @@ public class VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest extends Stud
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -89,14 +82,10 @@ public class VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest extends Stud
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -104,22 +93,10 @@ public class VerifyThatStudioDisplaysFieldsAsReadOnlyOnViewFormTest extends Stud
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysProperContentStateTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysProperContentStateTest.java
@@ -37,9 +37,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Content ID:24
 public class VerifyThatStudioDisplaysProperContentStateTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -59,10 +56,6 @@ public class VerifyThatStudioDisplaysProperContentStateTest extends StudioBaseTe
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -88,14 +81,10 @@ public class VerifyThatStudioDisplaysProperContentStateTest extends StudioBaseTe
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -103,23 +92,10 @@ public class VerifyThatStudioDisplaysProperContentStateTest extends StudioBaseTe
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest.java
@@ -35,10 +35,7 @@ import org.openqa.selenium.WebElement;
 
 // Test Case Studio- Site Content ID:16
 public class VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest extends StudioBaseTest {
-
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
+	;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String articlesFolder;
@@ -59,10 +56,6 @@ public class VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest extends S
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -90,14 +83,10 @@ public class VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest extends S
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -105,22 +94,10 @@ public class VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest extends S
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest.java
@@ -34,9 +34,6 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 // Test Case Studio- Site Content ID:9
 public class VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String articles2016Folder;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
@@ -54,10 +51,6 @@ public class VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest extends S
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.articles.2016folder");
 		selectAllSegmentsCheckBox = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -79,42 +72,22 @@ public class VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest extends S
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-	}
+		previewPage.clickSidebar()
+				.expandHomeTree();	}
 
 	public void createNewPageArticle(String folderLocation) {
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
 
 		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);
@@ -134,8 +107,6 @@ public class VerifyThatStudioDisplaysTheProperInfoOnContentToolTipTest extends S
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		
 		logger.info("Checking content info for Home page");
-		this.getWebDriverManager().clickElement("xpath", homeContent);
-		
 		String contentTypeInfo = this.getWebDriverManager().getContentTypeTooltipInfo(this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", homeContent));
 		String contentNameInfo = this.getWebDriverManager().getContentNameTooltipInfo(this.getWebDriverManager()

--- a/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contenttestcases/VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest.java
@@ -34,9 +34,6 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 // Test Case Studio- Site Content ID:8
 public class VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String articles2016Folder;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
@@ -54,10 +51,6 @@ public class VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest extends
 	@BeforeMethod
 	public void beforeTest(String siteId, String blueprint) {
 		apiTestHelper.createSite(siteId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articles2016Folder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.articles.2016folder");
 		selectAllSegmentsCheckBox = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -79,16 +72,10 @@ public class VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest extends
 	}
 
 	public void loginAndGoToPreview(String siteId) {
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
+		previewPage.clickSidebar()
+				.expandHomeTree();
 	}
 
 	public void createNewPageArticle(String folderLocation) {
@@ -96,25 +83,10 @@ public class VerifyThatStudioDisplaysTheProperPreviewInfoForAContentTest extends
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", folderLocation,
 				selectAllCategoriesCheckBox, selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor",
-				"ArticleSummary");
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
+				"ArticleSummary", "ArticleSection");
 	}
 
 	public void openSidebarAndGotoArticlesChildFolderAndCreatNewArticle() {
-
-		logger.info("Change Article Page body content to not required");
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
 		// expand Articles folder
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", articlesFolder);
 		dashboardPage.expandParentFolder(articlesFolder);

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DeleteOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DeleteOptionTest.java
@@ -34,33 +34,15 @@ import org.testng.annotations.Test;
 public class DeleteOptionTest extends StudioBaseTest {
 
 	private static final Logger logger = LogManager.getLogger(DeleteOptionTest.class);
-
-	private String userName;
-	private String password;
-
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String testingItemURLXpath;
-	private String studioLogo;
-
 	private String testItemXpath;
 
 	@Parameters({"testId", "blueprint"})
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		testingItemURLXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.myrecentactivity.firstelementurl");
-		studioLogo = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.studiologo");
 		testItemXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general" + ".testingcontentitem");
 	}
@@ -69,95 +51,20 @@ public class DeleteOptionTest extends StudioBaseTest {
 	@Test()
 	public void deletePageUsingContextualNavigationDeleteOptionTest(String testId) {
 		logger.info("Starting test case");
-		// login to application
-
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		// body not required
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		getWebDriverManager().getDriver().switchTo().defaultContent();
-
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		this.createContent();
-
-		this.getWebDriverManager().waitForAnimation();
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", studioLogo).click();
-
-		// wait for element is clickeable
-		this.getWebDriverManager().waitForAnimation();
-		dashboardPage.expandHomeTree();
-
+		previewPage.clickSidebar()
+				.createEntryContent("Test1", "Testing1", "title" + testId, "body" + testId)
+				.goToDashboard();
 		// Select the content to delete.
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", testItemXpath).click();
-
-		// click on delete option
 		previewPage.clickOnDeleteOption();
-
-		// Click on Delete dependencies
-
 		previewPage.clickOnDeleteDependencies();
-
-		// Click nn OK Delete dependencies
-
 		previewPage.clickOnOKDeleteDependencies();
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		this.getWebDriverManager().waitForAnimation();
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", studioLogo).click();
-
-		this.getWebDriverManager().waitForAnimation();
-		this.getWebDriverManager().waitForFullExpansionOfTree();
-		
-		this.getWebDriverManager().waitForAnimation();
+		previewPage.goToDashboard();
 		String contentDelete = this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", testingItemURLXpath).getText();
 		Assert.assertEquals(contentDelete, "/test1");
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createContent() {
-		logger.info("Creating new content");
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// Set basics fields of the new content created
-			this.getWebDriverManager().waitForAnimation();
-			dashboardPage.setBasicFieldsOfNewContent("Test1", "Testing1");
-
-			// Set the title of main content
-			this.getWebDriverManager().waitForAnimation();
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-			this.getWebDriverManager().waitForAnimation();
-			this.getWebDriverManager().waitForAnimation();
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-
-		});
-
 	}
 
 	@Parameters({"testId"})

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DuplicateOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/DuplicateOptionTest.java
@@ -21,8 +21,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.craftercms.studio.test.cases.StudioBaseTest;
 
 /**
@@ -33,77 +31,23 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 
 public class DuplicateOptionTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-
 	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElementId;
-	private String createFormMainTitleElementXPath;
-	private String studioLogo;
 	private String testItemXpath;
 	private String duplicateButtonXpath;
-
 	private String copyTestItemXpath;
-	private static Logger logger = LogManager.getLogger(DuplicateOptionTest.class);
 
 	@Parameters({"testId", "blueprint"})
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElementId = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
-		studioLogo = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.studiologo");
 		testItemXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitem");
 		duplicateButtonXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.duplicatedialog.duplicate");
 		copyTestItemXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.sitecontent.copytestitem");
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-
-	}
-
-	public void createNewContent() {
-
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-
-			// Set basics fields of the new content created
-			logger.info("Set the fields of the new content");
-			dashboardPage.setBasicFieldsOfNewContent("Test1", "Testing1");
-
-			// Set the title of main content
-
-			this.getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-			logger.info("Click on Save and close button");
-			this.getWebDriverManager()
-					.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", createFormSaveAndCloseElementId)
-					.click();
-
-		});
-
 	}
 
 	public void duplicateContentCreated() {
@@ -131,33 +75,11 @@ public class DuplicateOptionTest extends StudioBaseTest {
 	@Parameters({"testId"})
 	@Test()
 	public void duplicatePageUsingContextualNavigationDuplicateOptionOption(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// goto preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		// select the content type to the test
-		changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		// expand home content
-		this.getWebDriverManager().waitUntilPageLoad();
+		previewPage.clickSidebar();
 		this.getWebDriverManager().waitUntilSidebarOpens();
-		this.getWebDriverManager().waitForAnimation();
-		dashboardPage.expandHomeTree();
-
-		// create a new content
-		createNewContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.createEntryContent("Test1", "Testing1", "title" + testId, "body" + testId);
 
 		// Select the content to duplicate.
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", testItemXpath).click();
@@ -165,7 +87,7 @@ public class DuplicateOptionTest extends StudioBaseTest {
 		// Duplicate content created
 		duplicateContentCreated();
 
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", studioLogo).click();
+		previewPage.goToDashboard();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", copyTestItemXpath).click();
 		Assert.assertTrue(getWebDriverManager().isElementPresentByXpath(copyTestItemXpath),
 				"Duplicated Option is not displayed");

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/EditOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/EditOptionTest.java
@@ -35,8 +35,6 @@ public class EditOptionTest extends StudioBaseTest {
 
 	private static final Logger logger = LogManager.getLogger(EditOptionTest.class);
 
-	private String userName;
-	private String password;
 	private String adminConsoleXpath;
 	private String entryContentTypeBodyXpath;
 	private String entryContentTypeBodyCheckCss;
@@ -46,18 +44,14 @@ public class EditOptionTest extends StudioBaseTest {
 	private String createFormMainTitleElementXPath;
 	private String testingContentItem;
 	private String topNavEditOption;
-	private String siteDropDownXpath;
 	private String crafterLogoId;
 	private String testingItemEditedXpath;
-	private String siteDropdownListElementXPath;
 	private String lastPropertiesElementCssSelector;
 
 	@Parameters({"testId", "blueprint"})
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		adminConsoleXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.adminconsole");
 		entryContentTypeBodyXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -76,14 +70,10 @@ public class EditOptionTest extends StudioBaseTest {
 				.getProperty("general.testingcontentitem");
 		topNavEditOption= uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.edittopnavoption");
-		siteDropDownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		crafterLogoId = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.studiologo");
 		testingItemEditedXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitemedited.sitecontent");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		lastPropertiesElementCssSelector = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.entrycontenttype.propertiesdivlastelement");
 	}
@@ -171,18 +161,9 @@ public class EditOptionTest extends StudioBaseTest {
 	@Test()
 	public void verifyTheEditionOfAPageUsingContextualNavigationEditOptionTest(String testId) {
 		logger.info("Starting test case");
-		// login to application
-
-		loginPage.loginToCrafter(userName, password);
-
-		//Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		// Show site content panel
-		getWebDriverManager().clickElement("xpath", siteDropDownXpath);
+		previewPage.clickSidebar();
 		// Body Not requiered
 		bodyNotRequiered();
 

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/HistoryOptionTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/HistoryOptionTest.java
@@ -36,13 +36,9 @@ import org.openqa.selenium.TimeoutException;
 
 public class HistoryOptionTest extends StudioBaseTest{
 
-	private String userName;
-	private String password;
-	private String siteDropdownXpath;
 	private String homeXpath;
 	private String historyDialogTitle;
 	private String actionsHeaderXpath;
-	private String siteDropdownListElementXPath;
 
 	private static Logger logger = LogManager.getLogger(HistoryOptionTest.class);
 
@@ -50,34 +46,20 @@ public class HistoryOptionTest extends StudioBaseTest{
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		homeXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.home");
 		historyDialogTitle = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.historydialogtitle");
 		actionsHeaderXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.historydialogactionsheader");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 	}
 
 	@Parameters({"testId"})
 	@Test()
 	public void verifyThatTheHistoryDialogIsDisplayedTest(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-		
-		//Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-		
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		getWebDriverManager().clickElement("xpath", siteDropdownXpath);
+		previewPage.clickSidebar();
 		
 		this.getWebDriverManager().waitUntilSidebarOpens();
 		

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/PublishingSiteTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/PublishingSiteTest.java
@@ -40,11 +40,7 @@ import org.openqa.selenium.TimeoutException;
  */
 
 public class PublishingSiteTest extends StudioBaseTest {
-	private String userName;
-	private String password;
-	private String createFormFrameElementCss;
-	private String createFormMainTitleElementXPath;
-	private String createFormSaveAndCloseElement;
+
 	private String testingContentItem;
 	private String topNavStatusIcon;
 	private String homeXpath;
@@ -56,14 +52,6 @@ public class PublishingSiteTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformframe");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
 		testingContentItem = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitem");
 		topNavStatusIcon = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -71,51 +59,6 @@ public class PublishingSiteTest extends StudioBaseTest {
 		homeXpath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.home");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
-
-	public void createNewContent() {
-
-		// right click to see the the menu
-
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-
-			// Set basics fields of the new content created
-
-			logger.info("Set the fields of the new content");
-
-			dashboardPage.setBasicFieldsOfNewContent("Test1", "Testing1");
-
-			// Set the title of main content
-
-			this.getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			logger.info("Click on Save and close button");
-
-			this.getWebDriverManager()
-
-					.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", createFormSaveAndCloseElement)
-					.click();
-
-		});
 
 	}
 
@@ -136,43 +79,11 @@ public class PublishingSiteTest extends StudioBaseTest {
 	@Parameters({"testId"})
 	@Test()
 	public void publishingSite(String testId) {
-
-		// login to application
-
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to closes
-
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// goto preview page
-
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
+		previewPage.clickSidebar()
+				.createEntryContent("Test1", "Testing1", "title" + testId, "body" + testId);
 
-		// select the content type to the test
-
-		changeBodyToNotRequiredOnEntryContent();
-
-		// Switch to the form
-
-		getWebDriverManager().getDriver().switchTo().defaultContent();
-
-		// expand pages folder
-
-		dashboardPage.expandPagesTree();
-
-		// expand home content
-		this.getWebDriverManager().waitUntilPageLoad();
-		this.getWebDriverManager().waitUntilSidebarOpens();
-	
-
-		dashboardPage.expandHomeTree();
-
-		// create a new content
-
-		createNewContent();
-
-		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", testingContentItem).click();
 
 		// approve and publish

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysPublishStatusDialogTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysPublishStatusDialogTest.java
@@ -31,11 +31,7 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 
 public class VerifyThatApplicationDisplaysPublishStatusDialogTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownXpath;
 	private String homeXpath;
-	private String siteDropdownListElementXPath;
 	private String publishStatusTitleText;
 	private String publishStatusProccessStatusText;
 
@@ -43,14 +39,8 @@ public class VerifyThatApplicationDisplaysPublishStatusDialogTest extends Studio
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		homeXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.home");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		publishStatusTitleText = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.publishingstatus.title");
 		publishStatusProccessStatusText = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -60,23 +50,9 @@ public class VerifyThatApplicationDisplaysPublishStatusDialogTest extends Studio
 	@Parameters({"testId"})
 	@Test()
 	public void verifyThatApplicationDisplaysPublishStatusDialogTest(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-		
-		//Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		getWebDriverManager().clickElement( "xpath", siteDropdownXpath);
-
-		// expand pages folder
-		previewPage.expandPagesTree();
-		
-		getWebDriverManager().getDriver().navigate().refresh();
-		
+		previewPage.clickSidebar();
 		// expand home content
 		previewPage.expandHomeTree();
 

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysTheInContextEditIconProperlyTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysTheInContextEditIconProperlyTest.java
@@ -24,8 +24,6 @@ import org.testng.annotations.Test;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.craftercms.studio.test.cases.StudioBaseTest;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebElement;
 
 /**
  * 

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClickedTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClickedTest.java
@@ -31,12 +31,7 @@ import org.craftercms.studio.test.cases.StudioBaseTest;
 
 public class VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClickedTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownXpath;
 	private String homeXpath;
-	private String siteDropdownListElementXPath;
-	private String searchBoxInput;
 	private String searchPageTitleXpath;
 	private String searchResultsCss;
 
@@ -44,16 +39,9 @@ public class VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClicked
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
+
 		homeXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.home");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
-		searchBoxInput=uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.searchpage.searchbox");
 		searchPageTitleXpath=uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.searchpage.title");
 		searchResultsCss= uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -63,21 +51,9 @@ public class VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClicked
 	@Parameters({"testId"})
 	@Test()
 	public void verifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClickedTest(String testId) {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-		
-		//Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		// Show site content panel
-		if (!(this.getWebDriverManager().waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
-				.getAttribute("class").contains("site-dropdown-open")))
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed( "xpath",
-				siteDropdownXpath).click();
+		previewPage.clickSidebar();
 
 		// expand pages folder
 		previewPage.expandPagesTree();
@@ -95,9 +71,9 @@ public class VerifyThatApplicationDisplaysTheSearchPageWhenSearchOptionIsClicked
 		// Assertions	
 		Assert.assertTrue(this.getWebDriverManager().getDriver().getCurrentUrl().contains("/studio/search?"));
 		String searchPlaceholder = this.getWebDriverManager().waitUntilElementIsDisplayed("xpath",searchPageTitleXpath).getAttribute("placeholder");
+		getWebDriverManager().waitUntilSidebarOpens();
 		Assert.assertTrue("Search".equalsIgnoreCase(searchPlaceholder));
 		this.getWebDriverManager().sendText("xpath", searchPageTitleXpath, "entry");
-		this.getWebDriverManager().clickElement("xpath", searchBoxInput);
 		Assert.assertTrue("entry.ftl".equals(this.getWebDriverManager().waitForNumberElementsToBe(
 				"cssselector", searchResultsCss, 1).getText()));
 	}

--- a/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatCompareHistoryWorksProperly.java
+++ b/src/test/java/org/craftercms/studio/test/cases/contextualnavigationtestcases/VerifyThatCompareHistoryWorksProperly.java
@@ -33,8 +33,6 @@ import org.openqa.selenium.TimeoutException;
  */
 public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String historyFirstItemCheckbBox;
 	private String historySecondItemCheckbBox;
 	private String differencesDialogId;
@@ -43,7 +41,6 @@ public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 	private String createFormFrameElementCss;
 	private String createFormTitleElementXPath;
 	private String actionsHeaderXpath;
-	private String siteDropdownElementXPath;
 	private String firstItemRevertXpath;
 	private String historyRevertButtonXpath;
 	private static Logger logger = LogManager.getLogger(VerifyThatCompareHistoryWorksProperly.class);
@@ -52,9 +49,6 @@ public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-
 		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		createFormTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -71,8 +65,6 @@ public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 				.getProperty("complexscenarios.crafter3loadtest.differencedialog_addedmark");
 		actionsHeaderXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.historydialogactionsheader");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		firstItemRevertXpath = uiElementsPropertiesManager.getSharedDataOfExecutionLocators()
 				.getProperty("complexscenarios.crafter3loadtest.historydialog.initialcommittrevertbutton");
 		historyRevertButtonXpath = uiElementsPropertiesManager.getSharedDataOfExecutionLocators()
@@ -80,15 +72,9 @@ public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 	}
 
 	public void loginAndGoToSiteContentPagesStructure(String testId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-		this.getWebDriverManager().waitForAnimation();
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-		getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
+		previewPage.clickSidebar();
 	}
 
 	public void editSelectedContent() {
@@ -151,6 +137,7 @@ public class VerifyThatCompareHistoryWorksProperly extends StudioBaseTest {
 
 		getWebDriverManager().waitForNumberElementsToBe("xpath", historyRevertButtonXpath, 2);
 		getWebDriverManager().clickElement("xpath", firstItemRevertXpath);
+		getWebDriverManager().clickElement("xpath", ".//*[@aria-expanded='true']/..//a[@class='confirm']");
 		getWebDriverManager().waitForNumberElementsToBe("xpath", historyRevertButtonXpath, 3);
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/dashboardtestcases/RecentActivityFilterShowTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/dashboardtestcases/RecentActivityFilterShowTest.java
@@ -36,13 +36,6 @@ public class RecentActivityFilterShowTest extends StudioBaseTest {
 
 	private static final Logger logger = LogManager.getLogger(RecentActivityFilterShowTest.class);
 
-	private String userName;
-	private String password;
-
-	private String createFormFrameElementCss;
-	private String createFormMainTitleElementXPath;
-	private String createFormExpandAll;
-	private String createFormSaveAndCloseElement;
 	private String homeElementXPath;
 	private String myRecentActivityShowInputXPath;
 	private String myRecentActivityFirstItemURLXPath;
@@ -52,16 +45,6 @@ public class RecentActivityFilterShowTest extends StudioBaseTest {
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormExpandAll = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformexpandall");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformMainTitle");
 		homeElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.home");
 		myRecentActivityShowInputXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.myrecentactivity.showinput");
@@ -70,78 +53,6 @@ public class RecentActivityFilterShowTest extends StudioBaseTest {
 		myRecentActivitySecondItemURLXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.myrecentactivity.secondelementurl");
 
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-
-	}
-
-	public void createContent() {
-		logger.info("Creating first content");
-
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssselector", createFormFrameElementCss, () -> {
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent("AboutUs", "AboutUs");
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// click necessary to validate all fields required
-			this.getWebDriverManager().scrollUp();
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormExpandAll).click();
-
-			// save and close
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-	}
-
-	public void createSecondContent() {
-		logger.info("Creating second content");
-
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		// right click to see the the menu
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().usingCrafterForm("cssselector", createFormFrameElementCss, () -> {
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent("AboutUs1", "AboutUs1");
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// click necessary to validate all fields required
-			this.getWebDriverManager().scrollUp();
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormExpandAll).click();
-
-			// save and close
-
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
 	}
 
 	public void filtersAndAsserts() {
@@ -182,38 +93,16 @@ public class RecentActivityFilterShowTest extends StudioBaseTest {
 	@Test()
 	public void verifyThatTheShowInputWorksProperlyOnRecentActivityWidgetTest(String testId) {
 		logger.info("Starting test case");
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(testId);
-
-		// body not requiered
-		changeBodyToNotRequiredOnEntryContent();
-
-		dashboardPage.expandPagesTree();
-
-		// create content
-		createContent();
-
-		// expand home
-		dashboardPage.expandHomeTree();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
+		previewPage.clickSidebar();
+		previewPage.createEntryContent("AboutUs", "AboutUs", "title" + testId, "body" + testId);
 
 		// create a content with level descriptor content type
 		// create another content to use a filter
 		this.getWebDriverManager().isElementPresentAndClickableByXpath(homeElementXPath);
-		createSecondContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
+		previewPage.createEntryContent("AboutUs1", "AboutUs1", "title" + testId, "body" + testId);
+		previewPage.goToDashboard();
 		// filters and asserts
 		this.filtersAndAsserts();
 

--- a/src/test/java/org/craftercms/studio/test/cases/generaltestcases/ChangeStateOfPreviousPublishedContent.java
+++ b/src/test/java/org/craftercms/studio/test/cases/generaltestcases/ChangeStateOfPreviousPublishedContent.java
@@ -38,8 +38,6 @@ import org.openqa.selenium.WebElement;
 
 public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String selectAllSegmentsCheckBox;
 	private String selectAllCategoriesCheckBox;
 	private String userOptions;
@@ -52,7 +50,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 	private String dependenciesMenuOption;
 	private String staticAssetsChildFolder;
 	private String staticAssetsImagesChildFolder;
-	private String generalSiteDropdown;
 	private String pageStatus;
 	private String staticAssetsGearImageXpath;
 	private String articlesFolder;
@@ -61,7 +58,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 	private String expandPagesTree;
 	private String editedPageArticleName;
 	private String articleTitle;
-	private String siteDropdownElementXPath;
 	private String articleContentCreatedName;
 	private String gearImageXpath;
 	private int numberOfAttemptsForElementsDisplayed;
@@ -72,8 +68,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 	public void beforeTest(String testId, String blueprint, String testUser, String testGroup) {
 		apiTestHelper.createSite(testId, "", blueprint);
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		articlesFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.articlesfolder");
 		selectAllSegmentsCheckBox = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -99,8 +93,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 				.getProperty("preview.static_assets_child_folder");
 		staticAssetsImagesChildFolder = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("preview.static_assets_images_child_folder");
-		generalSiteDropdown = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		pageStatus = uiElementsPropertiesManager.getSharedUIElementsLocators().getProperty("general.pageStatus");
 		staticAssetsGearImageXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("preview.staticassets.gear.image.xpath");
@@ -114,22 +106,12 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 				.getProperty("complexscenarios.general.editedarticlename");
 		articleTitle = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.cssarticletitle");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdown");
 		articleContentCreatedName = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitem");
 		gearImageXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.gearimagexpath");
 		this.numberOfAttemptsForElementsDisplayed = Integer.parseInt(constantsPropertiesManager
 				.getSharedExecutionConstants().getProperty("crafter.numberofattemptsforelementdisplayed"));
-
-	}
-
-	public void login(String user, String loginpassword) {
-		// login to application
-		loginPage.loginToCrafter(user, loginpassword);
-		// Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
 
 	}
 
@@ -157,13 +139,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 		});
 
 		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
-
-	public void changeBodyToNotRequiredOnPageArticleContent() {
-		previewPage.changeBodyOfArticlePageToNotRequired();
-
-		previewPage.changeDateOfArticlePageToNotRequired();
 
 	}
 
@@ -212,8 +187,6 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath",
 				".//span[contains(text(),'" + newPageArticleName + "')]").click();
 
-		this.getWebDriverManager().getDriver().navigate().refresh();
-
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", requestPublishButton);
 
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", requestPublishButton)
@@ -230,39 +203,19 @@ public class ChangeStateOfPreviousPublishedContent extends StudioBaseTest {
 
 		// Related to the bug:
 		// issue https://github.com/craftercms/craftercms/issues/1557
-		this.login(userName, password);
+		loginPage.loginToCrafter();
 
 		logger.info("Go to Site Preview {}", siteId);
 		homePage.goToPreviewPage(siteId);
 
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
-		this.getWebDriverManager().waitUntilFolderOpens("xpath", expandPagesTree);
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-
-		// body not required Page-Article
-		logger.info("Change Article Page body content to not required");
-
-		this.changeBodyToNotRequiredOnPageArticleContent();
-
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayedAndClickable("id",
-
-				"admin-console");
-
-		// expand Home tree
-		this.getWebDriverManager().waitUntilFolderOpens("xpath", expandPagesTree);
+		previewPage.clickSidebar();
 
 		this.dashboardPage.expandHomeTree();
-
-		//this.getWebDriverManager().getDriver().navigate().refresh();
 
 		logger.info("Create Article Content");
 		this.getWebDriverManager().waitForAnimation();
 		previewPage.createPageArticleContent("test", "Testing1", "test", articlesFolder, selectAllCategoriesCheckBox,
-
-				selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor", "ArticleSummary");
+				selectAllSegmentsCheckBox, "ArticleSubject", "ArticleAuthor", "ArticleSummary", "ArticleSection");
 
 		// Switch back to the dashboard page
 		this.getWebDriverManager().getDriver().switchTo().activeElement();

--- a/src/test/java/org/craftercms/studio/test/cases/generaltestcases/VerifyThatNoBluePrintErrorsDisplayedWhenCreateSite.java
+++ b/src/test/java/org/craftercms/studio/test/cases/generaltestcases/VerifyThatNoBluePrintErrorsDisplayedWhenCreateSite.java
@@ -37,7 +37,6 @@ public class VerifyThatNoBluePrintErrorsDisplayedWhenCreateSite extends StudioBa
 	private String userName;
 	private String password;
 	private String createSiteErrorNotificationWindow;
-	private String menuSitesButton;
 	private String siteDropdownElementXPath;
 
 
@@ -47,8 +46,6 @@ public class VerifyThatNoBluePrintErrorsDisplayedWhenCreateSite extends StudioBa
 		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		createSiteErrorNotificationWindow = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.sites.createsite.errowindow");
-		menuSitesButton = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("preview.sites.menu.button");
 		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.sitedropdown");
 

--- a/src/test/java/org/craftercms/studio/test/cases/previewtoolstestcases/PresetEachDesignTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/previewtoolstestcases/PresetEachDesignTest.java
@@ -17,113 +17,44 @@
 package org.craftercms.studio.test.cases.previewtoolstestcases;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.craftercms.studio.test.cases.StudioBaseTest;
 
 /**
- * 
+ *
  * @author Gustavo Andrei Ortiz Alfaro
  *
  */
 
-public class PresetEachDesignTest extends StudioBaseTest{	
-	private String userName;
-	private String password;
+public class PresetEachDesignTest extends StudioBaseTest{
 
+	@Parameters({"testId", "blueprint"})
 	@BeforeMethod
-	public void beforeTest() {
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-
-	}
-
-	public void changeBodyToNotRequiredOnEntryContent() {
-
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-
-	}
-
-	public void createContent() {
-		// right click to see the the menu
-
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-
-		dashboardPage.clickOKButton();
-
-		// Switch to the iframe
-		getWebDriverManager().getDriver().switchTo().defaultContent();
-		getWebDriverManager().getDriver().switchTo()
-				.frame(this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
-						"cssSelector", ".studio-ice-dialog > .bd iframe"));					
-
-		// Set basics fields of the new content created
-		dashboardPage.setBasicFieldsOfNewContent("PRESET", "PRESET TESTING");
-
-		// Set the title of main content
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
-				"cssSelector", "#title > div > input").sendKeys("MainTitle");
-	
-
-		// click necessary to validate all fields required
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
-				"cssSelector", "#cstudio-form-expand-all").click();
-
-		// save and close
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
-				"id", "cstudioSaveAndClose").click();
-	
-		// Switch back to the dashboard page
-		getWebDriverManager().getDriver().switchTo().defaultContent();
-
+	public void beforeTest(String testId, String blueprint) {
+		apiTestHelper.createSite(testId, "", blueprint);
 	}
 
 	public void presets() {
-
 		// open publishing channel combo
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
 				"cssSelector", "#medium-panel-elem > div.acn-accordion-header > a").click();
 
 		 String contentURL = this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
 					"cssSelector", "#engineWindow").getText();
-		
+		//Todo: use dropdown options and assert width height
 		 Assert.assertTrue(contentURL.contains(contentURL));
 	}
 
-	@Test(priority = 0)
-
-	public void verifyTheDesingOfPresetsOnPreviewToolsTest() {
-
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-		
-		//Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
-		homePage.goToPreviewPage();
-
-		// body not required
-		changeBodyToNotRequiredOnEntryContent();
-
-		// expand pages folder
-		dashboardPage.expandPagesTree();
-
-		// create content
-		createContent();
-
-		// Expand Home Tree
-		dashboardPage.expandHomeTree();
-
-		// select content
-		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
-				"cssSelector", "#ygtvlabelel3").click();
-		
+	@Parameters({"testId"})
+	@Test()
+	public void verifyTheDesingOfPresetsOnPreviewToolsTest(String testId) {
+		loginPage.loginToCrafter();
+		homePage.goToPreviewPage(testId);
+		previewPage.clickSidebar()
+				.createEntryContent("PRESET", "PRESET TESTING", "title", "body");
 		// open tools
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed(
 				"cssSelector", "#acn-preview-tools-image").click();
@@ -133,4 +64,9 @@ public class PresetEachDesignTest extends StudioBaseTest{
 
 	}
 
+	@Parameters({"testId"})
+	@AfterMethod(alwaysRun = true)
+	public void afterTest(String testId) {
+		apiTestHelper.deleteSite(testId);
+	}
 }

--- a/src/test/java/org/craftercms/studio/test/cases/siteconfigtestcases/VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemoteTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/siteconfigtestcases/VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemoteTest.java
@@ -35,18 +35,11 @@ import org.craftercms.studio.test.utils.FilesLocations;
 // Test Case Studio - Site Config ID:58
 public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemoteTest extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownXpath;
 	private String adminConsoleXpath;
-	private String siteDropdownListElementXPath;
 	private String gitPrivateKey;
 	private String gitRepoUrl;
 	private String pushButtonXpath;
 	private String notificationText;
-	private String createFormFrameElementCss;
-	private String createFormSaveAndCloseElement;
-	private String createFormMainTitleElementXPath;
 	private String testingItemRecentActivity;
 	private String pullButtonXpath;
 	private String deleteButtonXpath;
@@ -57,16 +50,10 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 	@BeforeMethod
 	public void beforeTest(String testId, String blueprint, String remoteSshUrl) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		gitRepoUrl = remoteSshUrl;
 		gitPrivateKey = FilesLocations.PRIVATEKEYCONTENTFILEPATH;
-		siteDropdownXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitedropdown");
 		adminConsoleXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.adminconsole");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 		pushButtonXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("remoterepositories.newrepo.pushbutton");
 		pullButtonXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -75,36 +62,15 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 				.getProperty("remoterepositories.newrepo.deletebutton");
 		notificationText = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("remoterepositories.newrepo.push.notificationtext");
-		createFormFrameElementCss = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.createformframe");
-		createFormSaveAndCloseElement = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.saveandclosebutton");
-		createFormMainTitleElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.createformTitle");
 		testingItemRecentActivity = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.testingcontentitem.myrecentactivity");
-
 	}
 
 	public void step1(String siteId) {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to closes
-		getWebDriverManager().waitUntilLoginCloses();
-
-		// go to preview page
+		loginPage.loginToCrafter();
 		homePage.goToPreviewPage(siteId);
-
-		// Show site content panel
-		if (!(this.getWebDriverManager().waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
-				.getAttribute("class").contains("site-dropdown-open")))
-			this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", siteDropdownXpath)
-					.click();
-
-		logger.info("Going to Site Config page");
-		this.getWebDriverManager().clickElement("xpath", adminConsoleXpath);
-
+		previewPage.clickSidebar()
+				.clickAdminConsoleOption();
 	}
 
 	public void step2() {
@@ -124,62 +90,13 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 		this.goToDashboardAndCreateNewArticlePage();
 	}
 
-	public void changeBodyToNotRequiredOnEntryContent() {
-		previewPage.changeBodyOfEntryContentPageToNotRequired();
-	}
 
 	public void goToDashboardAndCreateNewArticlePage() {
-		// body not required for Entry content type
-		logger.info("Change the entry body content to not required");
-		this.changeBodyToNotRequiredOnEntryContent();
-
-		// go to sidebar
-		this.getWebDriverManager().waitUntilSidebarOpens();
-		// expand Pages tree
-		this.dashboardPage.expandPagesTree();
-
-		this.createContent();
-
-		// reload page
-		getWebDriverManager().getDriver().navigate().refresh();
-
-		// dashboardPage.expandHomeTree();
-
+		previewPage.goToDashboard();
+		previewPage.createEntryContent("Test", "Testing1", "Title", "Body");
 		Assert.assertNotNull(getWebDriverManager().waitUntilElementIsDisplayed("xpath", testingItemRecentActivity));
 	}
 
-	public void createContent() {
-		// right click to see the the menu
-		logger.info("Creating a new entry content on Home");
-		getWebDriverManager().waitUntilPageLoad();
-		getWebDriverManager().waitUntilSidebarOpens();
-		dashboardPage.rightClickToSeeMenu();
-
-		// Select Entry Content Type
-		dashboardPage.clickEntryCT();
-
-		// Confirm the Content Type selected
-		dashboardPage.clickOKButton();
-
-		getWebDriverManager().usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
-			// creating random values for URL field and InternalName field
-
-			// Set basics fields of the new content created
-			dashboardPage.setBasicFieldsOfNewContent("Test", "Testing1");
-
-			// Set the title of main content
-			getWebDriverManager().sendText("xpath", createFormMainTitleElementXPath, "MainTitle");
-
-			// save and close
-
-			this.getWebDriverManager()
-					.driverWaitUntilElementIsPresentAndDisplayed("xpath", createFormSaveAndCloseElement)
-					.click();
-		});
-
-		this.getWebDriverManager().waitUntilSidebarOpens();
-
-	}
 
 	public void step10() {
 		this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath", adminConsoleXpath).click();
@@ -198,9 +115,9 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 		Assert.assertTrue(
 				this.getWebDriverManager().waitUntilElementIsDisplayed("xpath", notificationText)
 						.getText().contains("Successfully Pushed"));
-		
+
 		this.getWebDriverManager().waitUntilNotificationModalIsNotPresent();
-		
+
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().getDriver().switchTo().defaultContent();
 
@@ -217,7 +134,7 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 						.getText().contains("Successfully Pulled"));
 
 		this.getWebDriverManager().waitUntilNotificationModalIsNotPresent();
-		
+
 		this.getWebDriverManager().getDriver().switchTo().defaultContent();
 	}
 
@@ -233,7 +150,7 @@ public class VerifyThatStudioAllowsToAddRemoteRepositoryAndPushAndPullFromRemote
 						.getText().contains("deleted."));
 
 		this.getWebDriverManager().waitUntilNotificationModalIsNotPresent();
-		
+
 		this.getWebDriverManager().waitForAnimation();
 		this.getWebDriverManager().getDriver().switchTo().defaultContent();
 

--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser.java
@@ -41,7 +41,6 @@ import org.openqa.selenium.WebElement;
 public class VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser extends StudioBaseTest {
 
 	private String siteDropdownElementXPath;
-	private String pagesTreeLink;
 	private String pagesTree;
 	private String homeContent;
 	private String rightclickEditOption;
@@ -65,7 +64,6 @@ public class VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser ex
 	private LinkedList<String> rightClickOptionsListInCategoryLandingPage;
 	private LinkedList<String> rightClickOptionsListInMenStylesForWinterPage;
 	private String rightClickOptions;
-	private String siteDropdownListElementXPath;
 	private static Logger logger = LogManager
 			.getLogger(VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser.class);
 
@@ -76,8 +74,6 @@ public class VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser ex
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
 		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
-		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sitecontent.expandpages");
 		pagesTree = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.expand_Pages_Tree");
 		homeContent = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -118,8 +114,6 @@ public class VerifyRightClickOptionsOfAPagesUnderPageStructureUsingAuthorUser ex
 				.getProperty("dashboard.articles.folder.2017.1.menstylesforwinter");
 		rightClickOptions = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("rightclick.list.all.options");
-		siteDropdownListElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownlielement");
 	}
 
 	public void rightClickHome() {

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithBasicAuthenticationTypeTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithBasicAuthenticationTypeTest.java
@@ -17,7 +17,6 @@
 package org.craftercms.studio.test.cases.sitestestcases;
 
 import org.craftercms.studio.test.cases.StudioBaseTest;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Parameters;

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneAuthenticationTypeTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneAuthenticationTypeTest.java
@@ -33,8 +33,6 @@ import org.testng.annotations.Test;
 public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneAuthenticationTypeTest
 		extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String siteId;
 	private String siteDropdownElementXPath;
 	private String emptyBPSiteId;
@@ -42,8 +40,6 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneA
 	@Parameters({"testId"})
 	@BeforeMethod
 	public void beforeTest(String testId) {
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.sitedropdown");
 		emptyBPSiteId = testId + "emptysitefornoneauth";
@@ -55,27 +51,16 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneA
 	}
 
 	public void step3() {
-		this.createSitePage.clickUseRemoteGitRepoSiteCheckbox();
-	}
-
-	public void step4() {
-		this.createSitePage.clickBasicInformation();
+		this.createSitePage.selectRemoteGitRepositorySite();
 	}
 
 	public void step5() {
 		createSitePage.setSiteName(siteId);
 	}
 
-	public void step6() {
-		createSitePage.clickBasicDeveloperOptions();
-	}
-
-	public void step7() {
-		createSitePage.setFromGitRepositoryName("origin");
-	}
 
 	public void step8() {
-		createSitePage.setFromGitRepositoryURL(this.getWebDriverManager().getAuthoringSiteSandboxRepoURL(emptyBPSiteId));
+		createSitePage.setRepositoryURL(this.getWebDriverManager().getAuthoringSiteSandboxRepoURL(emptyBPSiteId));
 	}
 
 	public void step10() {
@@ -109,17 +94,8 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneA
 		// Step 3
 		step3();
 
-		// Step 4
-		step4();
-
 		// Step 5
 		step5();
-
-		// Step 6
-		step6();
-
-		// Step 7
-		step7();
 
 		// Step 8
 		step8();
@@ -157,11 +133,7 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithNoneA
 	}
 
 	public void setup() {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		this.createSiteUsingEmptyBluePrint(emptyBPSiteId);
 	}
 

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPrivateKeyAuthenticationTypeOnLocalRepositoryTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPrivateKeyAuthenticationTypeOnLocalRepositoryTest.java
@@ -34,8 +34,6 @@ import org.testng.annotations.Test;
 public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPrivateKeyAuthenticationTypeOnLocalRepositoryTest
 		extends StudioBaseTest {
 
-	private String userName;
-	private String password;
 	private String siteId;
 	private String siteDropdownElementXPath;
 	private String gitPrivateKey;
@@ -45,8 +43,6 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPriva
 	@Parameters({"testId"})
 	@BeforeMethod
 	public void beforeTest(String testId) {
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
 		localRepoName = constantsPropertiesManager.getSharedExecutionConstants()
 				.getProperty("crafter.gitrepository.localrepositoryname");
 		gitPrivateKey = FilesLocations.PRIVATEKEYCONTENTFILEPATH;
@@ -69,16 +65,8 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPriva
 		createSitePage.setSiteName(siteId);
 	}
 
-	public void step5() {
-		createSitePage.clickAdditionalDeveloperOptions();
-	}
-
 	public void step6() {
 		createSitePage.clickPushSiteToRemoteGitCheckbox();
-	}
-
-	public void step7() {
-		createSitePage.setPushRepositoryName("origin");
 	}
 
 	public void step8() {
@@ -119,11 +107,7 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPriva
 	}
 
 	public void testScenario() {
-		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		// Step 2
 		step2();
 
@@ -133,14 +117,8 @@ public class VerifyStudioAllowsToCreateASiteBasedOnARemoteGitRepositoryWithPriva
 		// Step 4
 		step4();
 
-		// Step 5
-		step5();
-
 		// Step 6
 		step6();
-
-		// Step 7
-		step7();
 
 		// Step 8
 		step8();

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteWithLinkToUpstreamRemoteGitRepoWithPrivateKeyAuthenticationTypeTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToCreateASiteWithLinkToUpstreamRemoteGitRepoWithPrivateKeyAuthenticationTypeTest.java
@@ -18,7 +18,6 @@ package org.craftercms.studio.test.cases.sitestestcases;
 
 import org.craftercms.studio.test.cases.StudioBaseTest;
 import org.craftercms.studio.test.utils.FilesLocations;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Parameters;

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToFilterNumberOfSitesPerPage.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioAllowsToFilterNumberOfSitesPerPage.java
@@ -39,7 +39,6 @@ public class VerifyStudioAllowsToFilterNumberOfSitesPerPage extends StudioBaseTe
 	private String firstSiteXpath;
 	private String secondSiteXpath;
 	private String thirdSiteXpath;
-	private String createSiteButton;
 	private String lastNumberOfPaginationXpath;
 	private String firstNumberOfPaginationXpath;
 	private String lastArrowOfPaginationXpath;
@@ -61,8 +60,6 @@ public class VerifyStudioAllowsToFilterNumberOfSitesPerPage extends StudioBaseTe
 				.getProperty("general.sites.secondSiteNameOnList");
 		thirdSiteXpath= uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.sites.thirdSiteNameOnList");
-		createSiteButton = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.sites.createsitebutton");
 		lastNumberOfPaginationXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.sites.pagination.lastnumberelement");
 		firstNumberOfPaginationXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()

--- a/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioShowEachValidationOfFieldsForCreateSiteTest.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitestestcases/VerifyStudioShowEachValidationOfFieldsForCreateSiteTest.java
@@ -17,7 +17,6 @@
 package org.craftercms.studio.test.cases.sitestestcases;
 
 import org.craftercms.studio.test.cases.StudioBaseTest;
-import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -67,7 +66,7 @@ public class VerifyStudioShowEachValidationOfFieldsForCreateSiteTest extends Stu
 				.getProperty("home.createsite.repositoryprivatekeyvalidation");
 		siteIdNumericExpectedMsg = "Site names may not start with zeros, dashes (-) or underscores (_).";
 		siteIdRequiredExpectedMsg = "Site ID is required.";
-		gitRepoUrlExpectedMsg = "The git repository URL to push.";
+		gitRepoUrlExpectedMsg = "Git Repo URL is required.";
 		gitRepoPasswordExpectedMsg = "Password is required.";
 		gitRepoUsernameExpectedMsg  = "Username is required.";
 		gitRepoTokenExpectedMsg = "Token is required.";

--- a/src/test/java/org/craftercms/studio/test/pages/AccountManagementPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/AccountManagementPage.java
@@ -18,7 +18,6 @@ package org.craftercms.studio.test.pages;
 
 import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
 import org.craftercms.studio.test.utils.WebDriverManager;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 /**

--- a/src/test/java/org/craftercms/studio/test/pages/DashboardPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/DashboardPage.java
@@ -113,6 +113,9 @@ public class DashboardPage {
 	private String changeTemplateSubmitButtonLocator;
 	private String changeTemplateArticlesTitleLocator;
 	private String addCloseWinterWomanButton;
+	private String tinyMCEIframe;
+	private String tinyMCEBody;
+	private String iceFormIframe;
 	private static Logger logger = LogManager.getLogger(DashboardPage.class);
 
 	/**
@@ -273,6 +276,12 @@ public class DashboardPage {
 				.getProperty("dashboard.myrecentactivity.contentsecondicon");
 		authorReplaceImageButton = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("frame2.author.replaceimage");
+		tinyMCEIframe = uiElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("general.tinymce.iframe");
+		tinyMCEBody = uiElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("general.tinymce.body");
+		iceFormIframe = uiElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("general.createformframe");
 	}
 
 
@@ -511,9 +520,7 @@ public class DashboardPage {
 
 	// Click on save and close button
 	public void clickSaveClose() {
-		WebElement saveCloseButton = this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", this.saveCloseButton);
-		saveCloseButton.click();
+		driverManager.clickElement("xpath", this.saveCloseButton);
 	}
 
 	// Click on save and close button
@@ -921,10 +928,20 @@ public class DashboardPage {
 		driverManager.sendText("xpath", changeTemplateArticlesTitleLocator, articlesTitle);
 	}
 
-	public void setNewArticleContentSection(String subject, String author, String summary) {
+	public void setTinyMCEBody(String text) {
+		driverManager.getDriver().switchTo().frame(driverManager.findElement("cssselector", tinyMCEIframe));
+		driverManager.sendText("xpath", tinyMCEBody, text, false, false);
+		driverManager.getDriver().switchTo().defaultContent();
+		driverManager.getDriver().switchTo()
+				.frame(this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("cssSelector",
+						iceFormIframe));
+	}
+
+	public void setNewArticleContentSection(String subject, String author, String summary, String section) {
 		driverManager.sendText("xpath", articlesSubjectInput, subject);
 		driverManager.sendText("xpath", articlesAuthorInput, author);
 		driverManager.sendText("xpath", articlesSummaryInput, summary);
+		setTinyMCEBody(section);
 	}
 
 	public void selectFirstCategoryOfPagArticle() {
@@ -934,17 +951,11 @@ public class DashboardPage {
 	}
 
 	public void selectCategoriesOfNewPageArticle(String category) {
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", category);
-		WebElement categoryToCheck = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
-				category);
-		categoryToCheck.click();
+		driverManager.clickElement("xpath", category);
 	}
 
 	public void selectSegmentsOfNewPageArticle(String segments) {
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", segments);
-		WebElement segmentToCheck = this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath",
-				segments);
-		segmentToCheck.click();
+		driverManager.clickElement("xpath", segments);
 	}
 
 	public void selectAllTreeOnSelector(String folderXPath) {
@@ -1091,7 +1102,7 @@ public class DashboardPage {
 				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", parentElementLocator);
 		if (!parentElement.getAttribute("class").contains("open")) {
 			this.driverManager.waitUntilContentTooltipIsHidden();
-			parentElement.click();
+			driverManager.clickElement("xpath", parentElementLocator);
 		}
 	}
 
@@ -1155,15 +1166,8 @@ public class DashboardPage {
 
 		// Switch to the iframe
 		driverManager.getDriver().switchTo().defaultContent();
-		driverManager.getDriver().switchTo()
-				.frame(this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("cssSelector",
-						".studio-ice-dialog > .bd iframe"));
-		this.driverManager.isElementPresentAndClickableBycssSelector(".studio-ice-dialog > .bd iframe");
-		driverManager.getDriver().switchTo().defaultContent();
-		this.driverManager.getDriver().switchTo().frame(2);
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", addCloseGearImageButton)
-				.click();
+		this.driverManager.getDriver().switchTo().frame(3);
+		this.driverManager.clickElement("xpath", addCloseGearImageButton);
 
 	}
 
@@ -1183,7 +1187,7 @@ public class DashboardPage {
 						".studio-ice-dialog > .bd iframe"));
 		this.driverManager.isElementPresentAndClickableBycssSelector(".studio-ice-dialog > .bd iframe");
 		driverManager.getDriver().switchTo().defaultContent();
-		this.driverManager.getDriver().switchTo().frame(2);
+		this.driverManager.getDriver().switchTo().frame(3);
 		this.driverManager.scrollDown();
 		this.driverManager
 				.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", addCloseWinterWomanButton)

--- a/src/test/java/org/craftercms/studio/test/pages/DeliveryHomePage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/DeliveryHomePage.java
@@ -19,7 +19,6 @@ package org.craftercms.studio.test.pages;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.craftercms.studio.test.utils.WebDriverManager;
-import org.openqa.selenium.WebDriver;
 
 /**
  *

--- a/src/test/java/org/craftercms/studio/test/pages/HomePage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/HomePage.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.craftercms.studio.test.utils.UIElementsPropertiesManager;
 import org.craftercms.studio.test.utils.WebDriverManager;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 

--- a/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/PreviewPage.java
@@ -59,22 +59,16 @@ public class PreviewPage {
 	private String studioLogo;
 	private String siteDropdownElementXPath;
 	private String adminConsoleXpath;
-	private String entryContentTypeBodyXpath;
-	private String entryContentTypeBodyCheckXpath;
 	private String createFormFrameElementCss;
 	private String articleContentCreatedName;
 	private String generalDeleteOption;
 	private String generalEditOption;
 	private String siteStatusIcon;
-	private String siteContentXpath;
-	private String articlesContentTypeRepeatingGroup;
 	private String gearItemXpath;
 	private String bulkPublishTab;
 	private String publishingFrame;
 	private String siteDropdownListElementXPath;
-	private String lastPropertiesElementCssSelector;
 	private String dependenciesForXpath;
-	private String articlesContentTypeDate;
 	private String itemsTree;
 	private String itemsSubtree;
 	private String authorsTree;
@@ -84,6 +78,7 @@ public class PreviewPage {
 	private String inContextEditOption;
 	private String draftSavedNotification;
     private String engineWindowId;
+    private String sidebarTreeLoading;
 	private static Logger logger = LogManager.getLogger(PreviewPage.class);
 
 	public PreviewPage(WebDriverManager driverManager,
@@ -157,12 +152,6 @@ public class PreviewPage {
 				.getProperty("complexscenarios.general.sitedropdownlielement");
 		adminConsoleXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.adminconsole");
-		entryContentTypeBodyXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.entrycontenttype.body");
-		lastPropertiesElementCssSelector = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.entrycontenttype.propertiesdivlastelement");
-		entryContentTypeBodyCheckXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("general.entrycontenttype.bodyrequiredcheck");
 		createFormFrameElementCss = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.createformframe");
 		articleContentCreatedName = UIElementsPropertiesManager.getSharedUIElementsLocators()
@@ -173,12 +162,6 @@ public class PreviewPage {
 				.getProperty("general.edittopnavoption");
 		siteStatusIcon = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.statustopbaricon");
-		siteContentXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("dashboard.site_content");
-		articlesContentTypeRepeatingGroup = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.edit.articles.content.type.sections.repeating.group");
-		articlesContentTypeDate = UIElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.edit.articles.content.type.date");
 		gearItemXpath = UIElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("complexscenarios.general.gearlocator");
 		publishingFrame = UIElementsPropertiesManager.getSharedUIElementsLocators()
@@ -195,6 +178,8 @@ public class PreviewPage {
 				.getProperty("preview.saved_draft_notification");
         engineWindowId = UIElementsPropertiesManager.getSharedUIElementsLocators()
                 .getProperty("general.sites.iframe.engine.id");
+        sidebarTreeLoading = UIElementsPropertiesManager.getSharedUIElementsLocators()
+				.getProperty("general.sidebar.loading");
 	}
 
 	// Click on admin console link
@@ -449,40 +434,6 @@ public class PreviewPage {
 		this.saveAndCloseButton();
 	}
 
-	public void changeBodyOfEntryContentPageToNotRequired() {
-		// Show site content panel
-		this.driverManager.clickElement("xpath", siteDropdownElementXPath);
-		// go to admin console page
-		this.driverManager.clickElement("xpath", adminConsoleXpath);
-		// select content types
-		siteConfigPage.selectContentTypeOption();
-		// open content types
-		siteConfigPage.clickExistingTypeOption();
-		// Confirm the content type selected
-		siteConfigPage.confirmContentTypeSelected();
-		// wait for element is clickeable
-		driverManager.getDriver().switchTo().defaultContent();
-		// select main content
-		this.driverManager.waitUntilSiteConfigMaskedModalCloses();
-		this.driverManager.waitForAnimation();
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", entryContentTypeBodyXpath)
-				.click();
-		// Mark Body not required
-		this.driverManager.waitForAnimation();
-		this.driverManager.focusAndScrollDownToBottomInASection("#properties-container",
-				lastPropertiesElementCssSelector);
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayed("xpath", entryContentTypeBodyCheckXpath).click();
-		// save
-		this.driverManager.waitForAnimation();
-		siteConfigPage.saveDragAndDropProcess();
-		driverManager.getDriver().switchTo().defaultContent();
-		// go to dashboard
-		this.driverManager.getDriver().navigate().refresh();
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", studioLogo)
-				.click();
-	}
-
 	public void modifyPageXMLDefinitionContentAsFolderEntryContentType(String configurationSetUp) {
 		// Show site content panel
 		if (!(this.driverManager.waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
@@ -584,80 +535,9 @@ public class PreviewPage {
 				.click();
 	}
 
-	public void changeDateOfArticlePageToNotRequired() {
-		// Show site content panel
-		if (!(this.driverManager.waitUntilElementIsPresent("xpath", siteDropdownListElementXPath)
-				.getAttribute("class").contains("site-dropdown-open")))
-			this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", siteContentXpath).click();
-		// go to admin console page
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", adminConsoleXpath).click();
-		// Click on Content Types Option
-		siteConfigPage.clickContentTypeOption();
-		// open content types
-		siteConfigPage.clickExistingTypeOption();
-		// select content types
-		siteConfigPage.selectPageArticleContentType();
-		// Confirm the content type selected
-		siteConfigPage.confirmContentTypeSelected();
-		// wait for element is clickeable
-		driverManager.getDriver().switchTo().defaultContent();
-		// Scroll Down to select the item
-		this.driverManager.scrollDown();
-		// select main content
-		this.driverManager.waitForAnimation();
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", articlesContentTypeDate)
-				.click();
-		// Mark Body not required
-		this.driverManager.waitForAnimation();
-		this.driverManager.focusAndScrollDownToBottomInASection("#properties-container",
-				lastPropertiesElementCssSelector);
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayed("xpath", entryContentTypeBodyCheckXpath).click();
-		// save
-		siteConfigPage.saveDragAndDropProcess();
-		this.driverManager.getDriver().switchTo().defaultContent();
-		// go to dashboard
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", studioLogo)
-				.click();
-	}
-
-	public void changeBodyOfArticlePageToNotRequired() {
-		// go to admin console page
-		this.driverManager.clickElement("xpath", adminConsoleXpath);
-		// Click on Content Types Option
-		siteConfigPage.clickContentTypeOption();
-		// open content types
-		siteConfigPage.clickExistingTypeOption();
-		// select content types
-		siteConfigPage.selectPageArticleContentType();
-		// Confirm the content type selected
-		siteConfigPage.confirmContentTypeSelected();
-		// wait for element is clickeable
-		driverManager.getDriver().switchTo().defaultContent();
-		// Scroll Down to select the item
-		this.driverManager.scrollDown();
-		// select main content
-		this.driverManager.waitForAnimation();
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayed("xpath", articlesContentTypeRepeatingGroup)
-				.click();
-		// Mark Body not required
-		this.driverManager.waitForAnimation();
-		this.driverManager.focusAndScrollDownToBottomInASection("#properties-container",
-				lastPropertiesElementCssSelector);
-		this.driverManager
-				.driverWaitUntilElementIsPresentAndDisplayed("xpath", entryContentTypeBodyCheckXpath).click();
-		// save
-		siteConfigPage.saveDragAndDropProcess();
-		this.driverManager.getDriver().switchTo().defaultContent();
-		// go to dashboard
-		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", studioLogo)
-				.click();
-	}
-
 	public void createPageArticleContentUsingUploadedImage(String url, String name, String title,
 			String folderLocation, String selectedSegments, String selectedCategories, String subject,
-			String author, String summary) {
+			String author, String summary, String section) {
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", folderLocation);
 		// right click to see the the menu
 		dashboardPage.rightClickToSeeMenuOfSpecificFolder(folderLocation);
@@ -677,18 +557,17 @@ public class PreviewPage {
 			this.driverManager.waitForAnimation();
 			dashboardPage.setArticlesTitle(title);
 			this.driverManager.waitForAnimation();
-			// Fill the New Article Content Section
-			this.driverManager.scrollDown();
-			this.driverManager.waitForAnimation();
-			dashboardPage.setNewArticleContentSection(subject, author, summary);
-			// Select the catergory of the Article Page
 			this.driverManager.scrollMiddle();
 			this.driverManager.waitForAnimation();
+			// Select the catergory of the Article Page
 			dashboardPage.selectCategoriesOfNewPageArticle(selectedCategories);
 			// Select the segment of the Article Page
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectSegmentsOfNewPageArticle(selectedSegments);
+			// Fill the New Article Content Section
+			this.driverManager.waitForAnimation();
 			this.driverManager.scrollDown();
+			dashboardPage.setNewArticleContentSection(subject, author, summary, section);
 			// Add an Image
 			this.driverManager.waitForAnimation();
 			dashboardPage.addAnImageToAnArticleUsingUploadOption();
@@ -709,7 +588,7 @@ public class PreviewPage {
 
 	public void createPageArticleContent(String url, String name, String title, String folderLocation,
 			String selectedSegments, String selectedCategories, String subject, String author,
-			String summary) {
+			String summary, String section) {
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", folderLocation);
 		// right click to see the the menu
 		dashboardPage.rightClickToSeeMenuOfSpecificFolder(folderLocation);
@@ -728,20 +607,18 @@ public class PreviewPage {
 			this.driverManager.waitForAnimation();
 			dashboardPage.setArticlesTitle(title);
 			this.driverManager.waitForAnimation();
-			// Fill the New Article Content Section
-			this.driverManager.scrollDown();
-			this.driverManager.waitForAnimation();
-			dashboardPage.setNewArticleContentSection(subject, author, summary);
-			// Select the catergory of the Article Page
 			this.driverManager.scrollMiddle();
 			this.driverManager.waitForAnimation();
-			dashboardPage.selectCategoriesOfNewPageArticle(selectedCategories);
+			// Select the catergory of the Article Page
+			dashboardPage.setNewArticleContentSection(subject, author, summary, section);
 			// Select the segment of the Article Page
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectSegmentsOfNewPageArticle(selectedSegments);
-			this.driverManager.scrollDown();
-			// Add an Image
 			this.driverManager.waitForAnimation();
+			this.driverManager.scrollDown();
+			// Fill the New Article Content Section
+			dashboardPage.selectCategoriesOfNewPageArticle(selectedCategories);
+			// Add an Image
 			dashboardPage.addAnImageToAnArticle();
 			// Switch to the iframe
 			driverManager.getDriver().switchTo().defaultContent();
@@ -752,8 +629,7 @@ public class PreviewPage {
 			// save and close
 			this.driverManager.waitForAnimation();
 			this.driverManager.waitForFullExpansionOfTree();
-			this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("id", "cstudioSaveAndClose")
-					.click();
+			dashboardPage.clickSaveClose();
 		});
 		this.driverManager.waitUntilSidebarOpens();
 
@@ -761,7 +637,7 @@ public class PreviewPage {
 
 	public void createPageArticleContentUsingWinterWomanPicture(String url, String name, String title,
 			String folderLocation, String selectedSegments, String selectedCategories, String subject,
-			String author, String summary) {
+			String author, String summary, String section) {
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", folderLocation);
 		// right click to see the the menu
 		dashboardPage.rightClickToSeeMenuOfSpecificFolder(folderLocation);
@@ -779,12 +655,7 @@ public class PreviewPage {
 			dashboardPage.setInternalName1(name);
 			this.driverManager.waitForAnimation();
 			dashboardPage.setArticlesTitle(title);
-			this.driverManager.waitForAnimation();
 			// Fill the New Article Content Section
-			this.driverManager.scrollDown();
-			this.driverManager.waitForAnimation();
-			dashboardPage.setNewArticleContentSection(subject, author, summary);
-			// Select the catergory of the Article Page
 			this.driverManager.scrollMiddle();
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectCategoriesOfNewPageArticle(selectedCategories);
@@ -792,8 +663,10 @@ public class PreviewPage {
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectSegmentsOfNewPageArticle(selectedSegments);
 			this.driverManager.scrollDown();
-			// Add an Image
+			dashboardPage.setNewArticleContentSection(subject, author, summary, section);
+			// Select the catergory of the Article Page
 			this.driverManager.waitForAnimation();
+			// Add an Image
 			dashboardPage.addWinterWomanAssetImageToAnArticle();
 			// Switch to the iframe
 			driverManager.getDriver().switchTo().defaultContent();
@@ -804,8 +677,7 @@ public class PreviewPage {
 			// save and close
 			this.driverManager.waitForAnimation();
 			this.driverManager.waitForFullExpansionOfTree();
-			this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("id", "cstudioSaveAndClose")
-					.click();
+			dashboardPage.clickSaveClose();
 		});
 		this.driverManager.waitUntilSidebarOpens();
 
@@ -813,7 +685,7 @@ public class PreviewPage {
 
 	public void createPageArticleContentAsDraft(String url, String name, String title, String folderLocation,
 			String selectedSegments, String selectedCategories, String subject, String author,
-			String summary) {
+			String summary, String section) {
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayedAndClickable("xpath", folderLocation);
 		// right click to see the the menu
 		dashboardPage.rightClickToSeeMenuOfSpecificFolder(folderLocation);
@@ -831,12 +703,6 @@ public class PreviewPage {
 			dashboardPage.setInternalName1(name);
 			this.driverManager.waitForAnimation();
 			dashboardPage.setArticlesTitle(title);
-			this.driverManager.waitForAnimation();
-			// Fill the New Article Content Section
-			this.driverManager.scrollDown();
-			this.driverManager.waitForAnimation();
-			dashboardPage.setNewArticleContentSection(subject, author, summary);
-			// Select the catergory of the Article Page
 			this.driverManager.scrollMiddle();
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectCategoriesOfNewPageArticle(selectedCategories);
@@ -844,9 +710,10 @@ public class PreviewPage {
 			this.driverManager.waitForAnimation();
 			dashboardPage.selectSegmentsOfNewPageArticle(selectedSegments);
 			this.driverManager.scrollDown();
+			dashboardPage.setNewArticleContentSection(subject, author, summary, section);
+			// Select the catergory of the Article Page
 			// Add an Image
 			this.driverManager.waitForAnimation();
-
 			// Switch to the iframe
 			driverManager.getDriver().switchTo().defaultContent();
 			driverManager.getDriver().switchTo()
@@ -861,7 +728,6 @@ public class PreviewPage {
 					.click();
 			this.driverManager.waitUntilElementIsDisplayed("xpath", draftSavedNotification);
 			this.driverManager.waitUntilElementIsNotDisplayed("xpath", draftSavedNotification);
-			this.driverManager.waitForFullExpansionOfTree();
 			this.driverManager
 					.driverWaitUntilElementIsPresentAndDisplayedAndClickable("id", "colExpButtonBtn").click();
 
@@ -870,6 +736,32 @@ public class PreviewPage {
 					.click();
 		});
 		this.driverManager.waitUntilSidebarOpens();
+	}
+
+	public PreviewPage createEntryContent(String url, String name, String title, String body) {
+		// right click to see the the menu
+		dashboardPage.rightClickToSeeMenu();
+
+		// Select Entry Content Type
+		dashboardPage.clickEntryCT();
+
+		// Confirm the Content Type selected
+		dashboardPage.clickOKButton();
+
+		driverManager.usingCrafterForm("cssSelector", createFormFrameElementCss, () -> {
+			// creating random values for URL field and InternalName field
+
+			// Set basics fields of the new content created
+			dashboardPage.setPageURL1(url);
+			dashboardPage.setInternalName1(name);
+			dashboardPage.setArticlesTitle(title);
+			dashboardPage.setTinyMCEBody(body);
+			// save and close
+			dashboardPage.clickSaveClose();
+		});
+
+		driverManager.waitUntilSidebarOpens();
+		return this;
 	}
 
 	public void checkDependencies() {
@@ -882,7 +774,7 @@ public class PreviewPage {
 				dependenciesSelector);
 		Select categoriesDropDown = new Select(this.driverManager
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", dependenciesSelector));
-		categoriesDropDown.selectByValue("depends-on");
+		categoriesDropDown.selectByValue("depends-on-me");
 		this.driverManager.driverWaitUntilElementIsPresentAndDisplayed("xpath", gearItemXpath);
 		Assert.assertTrue(this.getDriverManager().isElementPresentByXpath(gearItemXpath));
 		this.driverManager
@@ -938,8 +830,7 @@ public class PreviewPage {
 			if ((dependentItemName.equalsIgnoreCase("home.ftl"))
 					|| (dependentItemName.equalsIgnoreCase("home.groovy"))
 					|| (dependentItemName.equalsIgnoreCase("strawberries.jpg"))
-					|| (dependentItemName.equalsIgnoreCase("Three"))
-					|| (dependentItemName.equalsIgnoreCase("Two"))
+					|| (dependentItemName.equalsIgnoreCase("feature.ftl"))
 					|| (dependentItemName.equalsIgnoreCase("Left Rail with Latest Articles"))) {
 				firstCheckPass = true;
 			}
@@ -947,9 +838,7 @@ public class PreviewPage {
 					|| (dependentItemLocation.equalsIgnoreCase("/scripts/pages/home.groovy"))
 					|| (dependentItemLocation.equalsIgnoreCase("/static-assets/images/strawberries.jpg"))
 					|| (dependentItemLocation
-							.equalsIgnoreCase("/site/components/features/sapien-veroeros.xml"))
-					|| (dependentItemLocation
-							.equalsIgnoreCase("/site/components/features/quam-lorem-ipsum.xml"))
+							.equalsIgnoreCase("/templates/web/components/feature.ftl"))
 					|| (dependentItemLocation.equalsIgnoreCase(
 							"/site/components/left-rails/left-rail-with-latest-articles.xml"))) {
 				secondCheckPass = true;
@@ -1585,7 +1474,7 @@ public class PreviewPage {
 	}
 
 	public void checkDependentItemsForTemplate(String templateName, WebElement element, boolean dependsOn) {
-		if (!dependsOn) {
+		if (dependsOn) {
 			checkDependsOn(templateName, element);
 		} else {
 			checkDependsOnMe(templateName, element);
@@ -1638,7 +1527,7 @@ public class PreviewPage {
 		boolean firstCheckPass = false;
 		boolean secondCheckPass = false;
 
-		if (!dependsOn) {
+		if (dependsOn) {
 			switch (componentName) {
 			case "Latest Articles Widget":
 				Assert.assertTrue(dependentItemName.equalsIgnoreCase("Left Rail with Latest Articles"));
@@ -1688,7 +1577,7 @@ public class PreviewPage {
 					secondCheckPass = true;
 				}
 				break;
-			case "Four":
+			case "Five":
 				if ((dependentItemName.equalsIgnoreCase("feature.ftl"))) {
 					firstCheckPass = true;
 				}
@@ -1714,6 +1603,8 @@ public class PreviewPage {
 				throw new IllegalArgumentException(
 						"No component case for provided component name: " + componentName);
 			}
+			Assert.assertTrue(firstCheckPass);
+			Assert.assertTrue(secondCheckPass);
 		}
 
 	}
@@ -1758,7 +1649,7 @@ public class PreviewPage {
 
 	public void checkNumberOfItemOnDependencies(String componentName, List<WebElement> dependeciesItems,
 			boolean dependsOn) {
-		if (!dependsOn) {
+		if (dependsOn) {
 			switch (componentName) {
 			case "Latest Articles Widget":
 				Assert.assertTrue(dependeciesItems.size() == 1);
@@ -1811,7 +1702,7 @@ public class PreviewPage {
 		} else {
 			switch (componentName) {
 			case "Home":
-				Assert.assertTrue(dependeciesItems.size() == 6);
+				Assert.assertTrue(dependeciesItems.size() == 5);
 				break;
 			case "Style":
 				Assert.assertTrue(dependeciesItems.size() == 2);
@@ -1831,7 +1722,7 @@ public class PreviewPage {
 			case "Header":
 				Assert.assertTrue(dependeciesItems.size() == 1);
 				break;
-			case "Four":
+			case "Five":
 				Assert.assertTrue(dependeciesItems.size() == 1);
 				break;
 			case "Left Rail with Latest Articles":
@@ -1949,6 +1840,16 @@ public class PreviewPage {
 
 	public PreviewPage clickSidebar() {
 		driverManager.clickElement("xpath", siteDropdownElementXPath);
+		return this;
+	}
+
+	public PreviewPage goToDashboard() {
+		driverManager.clickElement("xpath", studioLogo);
+		return this;
+	}
+
+	public PreviewPage waitForSidebarTreeLoading(int timeout) {
+		driverManager.waitUntilElementIsNotDisplayed("xpath", sidebarTreeLoading, timeout);
 		return this;
 	}
 }

--- a/src/test/java/org/craftercms/studio/test/utils/WebDriverManager.java
+++ b/src/test/java/org/craftercms/studio/test/utils/WebDriverManager.java
@@ -366,7 +366,7 @@ public class WebDriverManager {
 		logger.info("Waiting for element to be hidden: {} , {}", typeOfSelector, selectorValue);
 		By selector = getSelector(typeOfSelector, selectorValue);
 		new WebDriverWait(driver, timeOut).until(ExpectedConditions
-				.refreshed(ExpectedConditions.invisibilityOf(driver.findElement(selector))));
+				.refreshed(ExpectedConditions.invisibilityOfElementLocated(selector)));
 	}
 
 	public void waitUntilElementIsHidden(WebElement element) {
@@ -844,7 +844,7 @@ public class WebDriverManager {
 		String contentTypeInfo = "";
 
 		logger.debug("Moving pointer to element");
-		this.moveMouseToElementAndClick(element);
+		this.moveMouseToElement(element);
 
 		WebElement toolTip = this.waitUntilElementIsDisplayed("xpath", toolTipModal);
 
@@ -905,17 +905,23 @@ public class WebDriverManager {
 	}
 
 	public void sendText(String selectorType, String selectorValue, String text) {
-		sendText(selectorType, selectorValue, text, true);
+		sendText(selectorType, selectorValue, text, true, true);
 	}
 
-	public void sendText(String selectorType, String selectorValue, String text, boolean clearInput) {
+	public void sendText(String selectorType, String selectorValue, String text, Boolean clear) {
+		sendText(selectorType, selectorValue, text, clear, true);
+	}
+
+	public void sendText(String selectorType, String selectorValue, String text, boolean clearInput, boolean checkText) {
 		logger.debug("Filling element {}, {} with value {}", selectorType, selectorValue, text);
 		WebElement input = waitUntilElementIsClickable(selectorType, selectorValue);
 		if (clearInput) {
 			input.clear();
 		}
 		input.sendKeys(text);
-		waitUntilAttributeIs(selectorType, selectorValue, "value", text);
+		if (checkText) {
+			waitUntilAttributeIs(selectorType, selectorValue, "value", text);
+		}
 	}
 
 	public void sendTextByLineJS(String selectorType, String selectorValue, String filePath){
@@ -1154,8 +1160,7 @@ public class WebDriverManager {
 		String script;
 		String shell;
 
-		String folder = System.getProperty("user.dir") + File.separator + ".." +
-				File.separator + ".."
+		String folder = System.getProperty("user.dir") + File.separator + "craftercms"
 				+ File.separator + "crafter-delivery" + File.separator + "bin";
 
 		shell = "/bin/bash";
@@ -1206,7 +1211,7 @@ public class WebDriverManager {
 
 	@SuppressWarnings("deprecation")
 	public int goToFolderAndExecuteGitInitBareRepository(String repositoryName) {
-		String repositoryFolder = System.getProperty("user.dir") +File.separator + ".." + File.separator + ".."
+		String repositoryFolder = System.getProperty("user.dir") +File.separator + "craftercms"
 				+ File.separator + "crafter-authoring" + File.separator + "data" + File.separator + "craftercms_testrepos"
 				+ File.separator + repositoryName + File.separator;
 
@@ -1232,7 +1237,7 @@ public class WebDriverManager {
 
 	public int goToFolderAndExecuteDeleteBareRepositoryFolder(String repositoryName) {
 		try {
-			String repositoryFolder = System.getProperty("user.dir") + File.separator + ".." + File.separator + ".."
+			String repositoryFolder = System.getProperty("user.dir") + File.separator + "craftercms"
 					+ File.separator + "crafter-authoring" + File.separator + "data" + File.separator
 					+ "craftercms_testrepos";
 
@@ -1250,15 +1255,15 @@ public class WebDriverManager {
 	}
 
 	public String getLocalBareRepoURL(String repositoryName) {
-		String repositoryFolder = System.getProperty("user.dir") + File.separator + ".." + File.separator + ".."
+		String repositoryFolder = System.getProperty("user.dir") + File.separator + "craftercms"
 				+ File.separator + "crafter-authoring" + File.separator + "data" + File.separator
 				+ "craftercms_testrepos" + File.separator + repositoryName + File.separator;
 		return repositoryFolder;
 	}
 
 	public String getAuthoringSiteSandboxRepoURL(String siteID) {
-		String repositoryFolder = System.getProperty("user.dir") + File.separator + ".." + File.separator
-				+ ".." + File.separator + "crafter-authoring" + File.separator + "data" + File.separator
+		String repositoryFolder = System.getProperty("user.dir") + File.separator + "craftercms" + File.separator
+				+  "crafter-authoring" + File.separator + "data" + File.separator
 				+ "repos" + File.separator + "sites" + File.separator + siteID + File.separator + "sandbox";
 
 		return repositoryFolder;

--- a/src/test/resources/SharedUIElements.properties
+++ b/src/test/resources/SharedUIElements.properties
@@ -323,8 +323,8 @@ frame2.save_Draft = .//input[@id='cstudioSaveAndCloseDraft']
 frame2.articlestitlefield = .//div[@id='title_t']//input
 frame2.changetemplate.articlestitlefield= .//div[@id='articles_title_t']//input
 frame2.categoriesdropdownlist = .//div[@id='Articles-container']/div[2]/div/div[3]/div/select
-frame2.article_select_all_segments_checkbox = //*[@id='segments_o-all']
-frame2.select_All_Categories_CheckBox = //*[@id='categories_o-all']
+frame2.article_select_all_segments_checkbox = //input[@id='segments_o-all']
+frame2.select_All_Categories_CheckBox = //input[@id='categories_o-all']
 frame2.select_entertaiment_Category_CheckBox = //*[@id='categories_o-entertainment']
 frame2.article_subject_input = //*[@id='subject_t']/div/input
 frame2.article_author_input = //*[@id='author_s']/div/input
@@ -399,7 +399,7 @@ complexscenarios.crafter3loadtest.healthcontentpage=.//span[contains(text(),'Hom
 complexscenarios.crafter3loadtest.technologycontentpage=.//span[contains(text(),'Home')]/../../../../../div/div/table/tbody/tr/td/span[text()='Technology']
 complexscenarios.crafter3loadtest.historydialog.firstitemcheckbox = .//table[@id='history-versions-grid']/tbody//tr[1]//input
 complexscenarios.crafter3loadtest.historydialog.seconditemcheckbox = .//table[@id='history-versions-grid']/tbody//tr[2]//input
-complexscenarios.crafter3loadtest.historydialog.initialcommittrevertbutton = .//div[contains(@class,'bd cstudio-dialogue-body')]/div/div[2]/table/tbody/tr/td[3]/div[text()='Initial commit.']/../../td[4]/div/a[3]
+complexscenarios.crafter3loadtest.historydialog.initialcommittrevertbutton = .//div[contains(@class,'bd cstudio-dialogue-body')]/div/div[2]/table/tbody/tr/td[3]/div[text()='Initial commit.']/../../td[4]/div/div
 complexscenarios.crafter3loadtest.differencedialog_removedmark = .//td[text()='title_t']/../td[2]/span[contains(@class,'diff-html-removed')]
 complexscenarios.crafter3loadtest.differencedialog_addedmark = .//td[text()='title_t']/../td[2]/span[contains(@class,'diff-html-added')]
 complexscenarios.crafter3loadtest.historydialog.compareButton = historyCompareBtn
@@ -407,7 +407,7 @@ complexscenarios.renameparentpageandpublishchildtest.approvesubmitid =approveSub
 complexscenarios.renameparentpageandpublishchildtest.unselectallcheckbox =.//input[@id='publish-all-check']
 complexscenarios.renameparentpageandpublishchildtest.togglenavigationelement = .//span[text()='Toggle navigation']
 complexscenarios.general.homeexpansor = .//span[text()='Home']/../../td[1]
-complexscenarios.general.sitedropdownmenuinnerid = acn-dropdown-menu-inner  
+complexscenarios.general.sitedropdownmenuinnerid = acn-dropdown-menu-inner
 complexscenarios.general.sitedropdownmenuinnerxpath = //*[@id='acn-dropdown-inner']
 complexscenarios.general.approveforpublishdialogtitle = .//h3[text()='Approve for Publish']
 complexscenarios.general.differencedialogid= div.studio-ice-dialog.studio-ice-container.animated.ui-resizable > div.bd > iframe
@@ -433,7 +433,10 @@ complexscenarios.view.article.readonlybanner=.//div[@id='cstudio-form-readonly-b
 complexscenarios.view.article.buttons=.//div[@class='cstudio-form-controls-button-container']//input
 
 ##General used locators
-##Used on multiple classes 
+##Used on multiple classes
+general.tinymce.iframe = .tox-edit-area__iframe
+general.tinymce.body = .//body[@id='tinymce']
+general.ice.iframe = studio-ice-dialog > .bd iframe
 general.studiologo = .//img[@id='cstudio-logo']
 general.home =.//span[text()='Home']
 general.sitedropdown = .//a[@id='acn-dropdown-toggler']
@@ -512,7 +515,7 @@ preview.editorial.site.title =.//section[@id='banner']//h1/span
 preview.sites.menu.button = .//a[@id='sitesRightNav']
 preview.staticassets.gear.image.xpath = .//span[contains(text(),'1-gear.png')]
 preview.savedraftbar=.//div[@class='acnDraftContent']
-preview.saved_draft_notification=.//div[@id='saveDraftWar']/div[text()='Draft Save Completed']
+preview.saved_draft_notification=.//div[@class='notifyjs-corner']//span
 general.navigation_sitebar_name_id = .//a[@id='navbar-site-name']
 general.publishingstatustopnavoption = .//div[@id='acn-status']/span[@class='nav-icon fa fa-cloud-upload f18']
 general.publishingstatus.title=.//div[@id='status-dialog']//div[@class='hd']
@@ -696,7 +699,7 @@ general.components.latestarticleswidget=.//span[text()='Latest Articles Widget']
 general.components.headersfolder=.//span[text()='headers']
 general.components.header=.//span[text()='Header']
 general.components.featuresfolder=.//span[text()='features']
-general.components.four=.//span[text()='Four']
+general.components.five=.//span[text()='Five']
 general.components.leftrailsfolder=.//span[text()='left-rails']
 general.articles.wommenstyles=.//span[text()='Women Styles for Winter']
 general.components.leftrailwithlatestarticles=.//span[text()='Left Rail with Latest Articles']
@@ -744,7 +747,7 @@ general.onduplicate.internalname = .//div[@id='PageProperties-body']//div[@id='i
 #Other dialogs
 general.sidebar = div.acn-resize.ui-resizable
 general.yui.dialog = div.yui-panel-container.yui-dialog
-
+general.sidebar.loading = .//td[contains(@class,'ygtvloading')]
 #RightClick Selectors
 rightclick.edit.option = .//div[@id='acn-context-menu']/div[contains(@style,'visibility: visible')]//a[text()='Edit']
 rightclick.view.option = .//div[@id='acn-context-menu']/div[contains(@style,'visibility: visible')]//a[text()='View']

--- a/src/test/resources/testng_parallel.xml
+++ b/src/test/resources/testng_parallel.xml
@@ -17,7 +17,7 @@
   -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="craftercms - Studio UI -AllTestCases TestSuite" parallel="tests" thread-count="12" preserve-order="false">
+<suite name="craftercms - Studio UI -AllTestCases TestSuite" parallel="tests" thread-count="5" preserve-order="false">
 	<parameter name="blueprint" value="empty"/>
 	<test name="Open Studio Test">
 		<parameter name="testId" value="sanity001"/>
@@ -150,7 +150,7 @@
 		</classes>
 	</test>
 	<test name="Verify that studio allows to rename content via Form (page.xml move name)">
-		<parameter name="testId" value="content027"/>
+		<parameter name="testId" value="content026"/>
 		<parameter name="blueprint" value="empty"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.contenttestcases.RenameViaFormTest"/>
@@ -168,7 +168,6 @@
 		<parameter name="blueprint" value="empty"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.contenttestcases.CopyPasteToFolderTest"/>
-
 		</classes>
 	</test>
 	<test name="Verify that studio allows to copy and paste content to folder with collision and duplicate">
@@ -179,7 +178,7 @@
 		</classes>
 	</test>
 	<test name="Verify that studio allows to rename content via Form (page move name rename)">
-		<parameter name="testId" value="content026"/>
+		<parameter name="testId" value="content033"/>
 		<parameter name="blueprint" value="empty"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.contenttestcases.RenameViaFormPageMoveNameRenameTest"/>
@@ -317,8 +316,7 @@
 		<parameter name="testId" value="content016"/>
 		<parameter name="blueprint" value="editorial"/>
 		<classes>
-			<class
-					name="org.craftercms.studio.test.cases.contenttestcases.VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest"/>
+			<class name="org.craftercms.studio.test.cases.contenttestcases.VerifyThatStudioDisplaysProperlyTheHistoryForAContentTest"/>
 		</classes>
 	</test>
 	<test name="Verify that the application displays as read-only all the fields on the View form when the View option is clicked on the right click options">
@@ -459,7 +457,7 @@
 	<test name="Filter Activity Item Types Test">
 		<parameter name="testId" value="dashboard024"/>
 		<classes>
-			<class name="org.craftercms.studio.test.cases.dashboardtestcases.RecentActivityFilterShowTest"/>
+			<class name="org.craftercms.studio.test.cases.dashboardtestcases.RecentActivityItemTypesSectionTest"/>
 		</classes>
 	</test>
 	<test name="Filter Show Recent Activity Test">


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
* Remove username and password variables for some tests, the logic of login is already handled by the `LoginPage` 
* Remove the methods that changed the body and date to no required in the Content Type: 
`changeBodyOfArticlePageToNotRequired`, `changeDateOfArticlePageToNotRequired`, `changeBodyOfEntryContentPageToNotRequired` 
* Update the CreateArticles methods to add the text into the tinyMCE section, this is needed to resolve the previous problem of not requiring the body in the Content Type.
* Add a method to CreateEntry to a Page, this was copy-paste in a lot of test.
* Remove unused variables and imports
* General test cases updates. 
* Change from `getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);` to `previewPage.clickSidebar()` so the variables of test cases are removed and the logic of clicking the sidebar is in the  `PreviewPage`