### PR TITLE
Move expected items in sidebar to parameters of each test

### DIFF
--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminUser.java
@@ -38,9 +38,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Dropdown ID:1
 public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminUser extends StudioBaseTest {
 
-	private String userName;
-	private String password;
-	private String siteDropdownElementXPath;
 	private String dashboardLink;
 	private String pagesTreeLink;
 	private String componentsTreeLink;
@@ -49,17 +46,13 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminU
 	private String templatesTreeLink;
 	private String scriptsTreeLink;
 	private String siteConfigLink;
-	private LinkedList<String> siteDropdownItemsInExpectedOrder;
+	private String[] siteDropdownItemsInExpectedOrder;
 	private String siteDropdownItemsXpath;
 
-	@Parameters({"testId", "blueprint"})
+	@Parameters({"testId", "blueprint", "siteDropdownOrderItems"})
 	@BeforeMethod
-	public void beforeTest(String testId, String blueprint) {
+	public void beforeTest(String testId, String blueprint, String siteDropdownOrderItems) {
 		apiTestHelper.createSite(testId, "", blueprint);
-		userName = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.username");
-		password = constantsPropertiesManager.getSharedExecutionConstants().getProperty("crafter.password");
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.dashboard_menu_option");
 		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -78,36 +71,17 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminU
 				.getProperty("general.adminconsole");
 		siteDropdownItemsXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.sitebar.dropdown.items");
-		siteDropdownItemsInExpectedOrder = new LinkedList<String>();
-		siteDropdownItemsInExpectedOrder.add(0, "Dashboard");
-		siteDropdownItemsInExpectedOrder.add(1, "Pages");
-		siteDropdownItemsInExpectedOrder.add(2, "Components");
-		siteDropdownItemsInExpectedOrder.add(3, "Taxonomy");
-		siteDropdownItemsInExpectedOrder.add(4, "Static Assets");
-		siteDropdownItemsInExpectedOrder.add(5, "Templates");
-		siteDropdownItemsInExpectedOrder.add(6, "Scripts");
-		siteDropdownItemsInExpectedOrder.add(7, "Site Config");
-		siteDropdownItemsInExpectedOrder.add(8, "here");
-		siteDropdownItemsInExpectedOrder.add(9, "bug");
-		siteDropdownItemsInExpectedOrder.add(10, "Crafter News");
-
+		siteDropdownItemsInExpectedOrder = siteDropdownOrderItems.split(",");
 	}
 
 	@Parameters({"testId"})
 	@Test()
 	public void verifyTheSideBarDropdownOptionsUsingWebEditorialBlueprint(String testId) {
 		// login to application
-		loginPage.loginToCrafter(userName, password);
-
-		// Wait for login page to close
-		getWebDriverManager().waitUntilLoginCloses();
-
+		loginPage.loginToCrafter();
 		// go to preview page
 		homePage.goToPreviewPage(testId);
-
-		// Expand the site bar
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
+		previewPage.clickSidebar();
 		// Check all the section are present;
 		WebElement dashboardLinkElement = this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", dashboardLink);
@@ -150,7 +124,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminU
 		for (WebElement element : siteDropdownItems) {
 			this.getWebDriverManager().waitForAnimation();
 			this.getWebDriverManager().waitUntilSidebarOpens();
-			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder.get(currentIndex)),
+			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder[currentIndex]),
 					"ERROR: Link Option: " + element.getText() + " is not in the correct order");
 			currentIndex++;
 		}

--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthorUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthorUser.java
@@ -40,7 +40,6 @@ import org.openqa.selenium.WebElement;
 // Test Case Studio- Site Dropdown ID:3
 public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthorUser extends StudioBaseTest {
 
-	private String siteDropdownElementXPath;
 	private String dashboardLink;
 	private String pagesTreeLink;
 	private String componentsTreeLink;
@@ -48,18 +47,16 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthor
 	private String staticAssetsTreeLink;
 	private String templatesTreeLink;
 	private String scriptsTreeLink;
-	private LinkedList<String> siteDropdownItemsInExpectedOrder;
+	private String[] siteDropdownItemsInExpectedOrder;
 	private String siteDropdownItemsXpath;
 	private static Logger logger = LogManager
 			.getLogger(VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthorUser.class);
 
-	@Parameters({"testId", "blueprint", "testUser", "testGroup"})
+	@Parameters({"testId", "blueprint", "testUser", "testGroup", "siteDropdownOrderItems"})
 	@BeforeMethod
-	public void beforeTest(String testId, String blueprint, String testUser, String testGroup) {
+	public void beforeTest(String testId, String blueprint, String testUser, String testGroup, String siteDropdownOrderItems) {
 		apiTestHelper.createSite(testId, "", blueprint);
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.dashboard_menu_option");
 		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -76,17 +73,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthor
 				.getProperty("dashboard.expand_scripts_tree");
 		siteDropdownItemsXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.sitebar.dropdown.items");
-		siteDropdownItemsInExpectedOrder = new LinkedList<String>();
-		siteDropdownItemsInExpectedOrder.add(0, "Dashboard");
-		siteDropdownItemsInExpectedOrder.add(1, "Pages");
-		siteDropdownItemsInExpectedOrder.add(2, "Components");
-		siteDropdownItemsInExpectedOrder.add(3, "Taxonomy");
-		siteDropdownItemsInExpectedOrder.add(4, "Static Assets");
-		siteDropdownItemsInExpectedOrder.add(5, "Templates");
-		siteDropdownItemsInExpectedOrder.add(6, "Scripts");
-		siteDropdownItemsInExpectedOrder.add(7, "here");
-		siteDropdownItemsInExpectedOrder.add(8, "bug");
-		siteDropdownItemsInExpectedOrder.add(9, "Crafter News");
+		siteDropdownItemsInExpectedOrder = siteDropdownOrderItems.split(",");
 	}
 
 	@Parameters({"testId", "testUser"})
@@ -95,15 +82,9 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthor
 			String testId, String testUser) {
 		logger.info("login to application with {} user", testUser);
 		loginPage.loginToCrafter(testUser, testUser);
-		this.getWebDriverManager().waitUntilLoginCloses();
 		logger.info("Go to Preview Page {}", testId);
 		this.homePage.goToPreviewPage(testId);
-
-		// Expand the site bar
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
-		Assert.assertTrue(this.getWebDriverManager().isElementPresentAndClickableByXpath(siteDropdownElementXPath));
-
+		previewPage.clickSidebar();
 		// Check all the section are present;
 		WebElement dashboardLinkElement = this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dashboardLink);
@@ -138,7 +119,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthor
 		int currentIndex = 0;
 		for (WebElement element : siteDropdownItems) {
 			this.getWebDriverManager().waitUntilSidebarOpens();
-			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder.get(currentIndex)),
+			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder[currentIndex]),
 					"ERROR: Link Option: " + element.getText() + " is not in the correct order");
 			currentIndex++;
 		}

--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDeveloperUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDeveloperUser.java
@@ -41,7 +41,6 @@ import org.openqa.selenium.WebElement;
 public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDeveloperUser
 		extends StudioBaseTest {
 
-	private String siteDropdownElementXPath;
 	private String dashboardLink;
 	private String pagesTreeLink;
 	private String componentsTreeLink;
@@ -49,19 +48,17 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDevelo
 	private String staticAssetsTreeLink;
 	private String templatesTreeLink;
 	private String scriptsTreeLink;
-	private LinkedList<String> siteDropdownItemsInExpectedOrder;
+	private String[] siteDropdownItemsInExpectedOrder;
 	private String siteDropdownItemsXpath;
 	private String siteConfigLink;
 	private static Logger logger = LogManager
 			.getLogger(VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDeveloperUser.class);
 
-	@Parameters({"testId", "blueprint", "testUser", "testGroup"})
+	@Parameters({"testId", "blueprint", "testUser", "testGroup", "siteDropdownOrderItems"})
 	@BeforeMethod
-	public void beforeTest(String testId, String blueprint, String testUser, String testGroup) {
+	public void beforeTest(String testId, String blueprint, String testUser, String testGroup, String siteDropdownOrderItems) {
 		apiTestHelper.createSite(testId, "", blueprint);
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.dashboard_menu_option");
 		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -80,18 +77,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDevelo
 				.getProperty("dashboard.sitebar.dropdown.items");
 		siteConfigLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("general.adminconsole");
-		siteDropdownItemsInExpectedOrder = new LinkedList<String>();
-		siteDropdownItemsInExpectedOrder.add(0, "Dashboard");
-		siteDropdownItemsInExpectedOrder.add(1, "Pages");
-		siteDropdownItemsInExpectedOrder.add(2, "Components");
-		siteDropdownItemsInExpectedOrder.add(3, "Taxonomy");
-		siteDropdownItemsInExpectedOrder.add(4, "Static Assets");
-		siteDropdownItemsInExpectedOrder.add(5, "Templates");
-		siteDropdownItemsInExpectedOrder.add(6, "Scripts");
-		siteDropdownItemsInExpectedOrder.add(7, "Site Config");
-		siteDropdownItemsInExpectedOrder.add(8, "here");
-		siteDropdownItemsInExpectedOrder.add(9, "bug");
-		siteDropdownItemsInExpectedOrder.add(10, "Crafter News");
+		siteDropdownItemsInExpectedOrder = siteDropdownOrderItems.split(",");
 	}
 
 	@Parameters({"testId", "testUser"})
@@ -100,19 +86,9 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDevelo
 		// login to application with developer user
 		logger.info("login to application with {} user", testUser);
 		loginPage.loginToCrafter(testUser, testUser);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
 		logger.info("Go to Preview Page {}", testId);
 		this.homePage.goToPreviewPage(testId);
-
-		this.getWebDriverManager().waitForAnimation();
-
-		// Expand the site bar
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
-		Assert.assertTrue(this.getWebDriverManager().isElementPresentAndClickableByXpath(siteDropdownElementXPath));
-
+		previewPage.clickSidebar();
 		// Check all the section are present;
 		WebElement dashboardLinkElement = this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", dashboardLink);
@@ -154,7 +130,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDevelo
 		int currentIndex = 0;
 		for (WebElement element : siteDropdownItems) {
 			this.getWebDriverManager().waitUntilSidebarOpens();
-			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder.get(currentIndex)),
+			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder[currentIndex]),
 					"ERROR: Link Option: " + element.getText() + " is not in the correct order");
 			currentIndex++;
 		}

--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser.java
@@ -40,7 +40,6 @@ import org.openqa.selenium.WebElement;
 //Test Case Studio- Site Dropdown ID:5
 public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser extends StudioBaseTest {
 
-	private String siteDropdownElementXPath;
 	private String dashboardLink;
 	private String pagesTreeLink;
 	private String componentsTreeLink;
@@ -48,18 +47,16 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublis
 	private String staticAssetsTreeLink;
 	private String templatesTreeLink;
 	private String scriptsTreeLink;
-	private LinkedList<String> siteDropdownItemsInExpectedOrder;
+	private String[] siteDropdownItemsInExpectedOrder;
 	private String siteDropdownItemsXpath;
 	private static Logger logger = LogManager
 			.getLogger(VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser.class);
 
-	@Parameters({"testId", "blueprint", "testUser", "testGroup"})
+	@Parameters({"testId", "blueprint", "testUser", "testGroup", "siteDropdownOrderItems"})
 	@BeforeMethod
-	public void beforeTest(String testId, String blueprint, String testUser, String testGroup) {
+	public void beforeTest(String testId, String blueprint, String testUser, String testGroup, String siteDropdownOrderItems) {
 		apiTestHelper.createSite(testId, "", blueprint);
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.dashboard_menu_option");
 		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -76,17 +73,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublis
 				.getProperty("dashboard.expand_scripts_tree");
 		siteDropdownItemsXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.sitebar.dropdown.items");
-		siteDropdownItemsInExpectedOrder = new LinkedList<String>();
-		siteDropdownItemsInExpectedOrder.add(0, "Dashboard");
-		siteDropdownItemsInExpectedOrder.add(1, "Pages");
-		siteDropdownItemsInExpectedOrder.add(2, "Components");
-		siteDropdownItemsInExpectedOrder.add(3, "Taxonomy");
-		siteDropdownItemsInExpectedOrder.add(4, "Static Assets");
-		siteDropdownItemsInExpectedOrder.add(5, "Templates");
-		siteDropdownItemsInExpectedOrder.add(6, "Scripts");
-		siteDropdownItemsInExpectedOrder.add(7, "here");
-		siteDropdownItemsInExpectedOrder.add(8, "bug");
-		siteDropdownItemsInExpectedOrder.add(9, "Crafter News");
+		siteDropdownItemsInExpectedOrder = siteDropdownOrderItems.split(",");
 	}
 
 	@Parameters({"testId", "testUser"})
@@ -94,19 +81,9 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublis
 	public void verifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser(String testId, String testUser) {
 		logger.info("login to application with {} user", testUser);
 		loginPage.loginToCrafter(testUser, testUser);
-
-		getWebDriverManager().waitUntilLoginCloses();
-		
 		logger.info("Go to Preview Page {}", testId);
 		this.homePage.goToPreviewPage(testId);
-
-		this.getWebDriverManager().waitForAnimation();
-
-		// Expand the site bar
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-		
-		Assert.assertTrue(this.getWebDriverManager().isElementPresentAndClickableByXpath(siteDropdownElementXPath));
-		
+		previewPage.clickSidebar();
 		// Check all the section are present;
 		WebElement dashboardLinkElement = this.getWebDriverManager().driverWaitUntilElementIsPresentAndDisplayed("xpath",
 				dashboardLink);
@@ -142,7 +119,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublis
 		for (WebElement element : siteDropdownItems) {
 			this.getWebDriverManager().waitForAnimation();
 			this.getWebDriverManager().waitUntilSidebarOpens();
-			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder.get(currentIndex)),
+			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder[currentIndex]),
 					"ERROR: Link Option: " + element.getText() + " is not in the correct order");
 			currentIndex++;
 		}

--- a/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser.java
+++ b/src/test/java/org/craftercms/studio/test/cases/sitedropdowntestcases/VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser.java
@@ -41,7 +41,6 @@ import org.openqa.selenium.WebElement;
 public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser
 		extends StudioBaseTest {
 
-	private String siteDropdownElementXPath;
 	private String dashboardLink;
 	private String pagesTreeLink;
 	private String componentsTreeLink;
@@ -49,18 +48,16 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReview
 	private String staticAssetsTreeLink;
 	private String templatesTreeLink;
 	private String scriptsTreeLink;
-	private LinkedList<String> siteDropdownItemsInExpectedOrder;
+	private String[] siteDropdownItemsInExpectedOrder;
 	private String siteDropdownItemsXpath;
 	private static Logger logger = LogManager
 			.getLogger(VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser.class);
 
-	@Parameters({"testId", "blueprint", "testUser", "testGroup"})
+	@Parameters({"testId", "blueprint", "testUser", "testGroup", "siteDropdownOrderItems"})
 	@BeforeMethod
-	public void beforeTest(String testId, String blueprint, String testUser, String testGroup) {
+	public void beforeTest(String testId, String blueprint, String testUser, String testGroup, String siteDropdownOrderItems) {
 		apiTestHelper.createSite(testId, "", blueprint);
 		apiTestHelper.createUserAddToGroup(testUser, testGroup);
-		siteDropdownElementXPath = uiElementsPropertiesManager.getSharedUIElementsLocators()
-				.getProperty("complexscenarios.general.sitedropdownmenuinnerxpath");
 		dashboardLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.dashboard_menu_option");
 		pagesTreeLink = uiElementsPropertiesManager.getSharedUIElementsLocators()
@@ -77,18 +74,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReview
 				.getProperty("dashboard.expand_scripts_tree");
 		siteDropdownItemsXpath = uiElementsPropertiesManager.getSharedUIElementsLocators()
 				.getProperty("dashboard.sitebar.dropdown.items");
-
-		siteDropdownItemsInExpectedOrder = new LinkedList<String>();
-		siteDropdownItemsInExpectedOrder.add(0, "Dashboard");
-		siteDropdownItemsInExpectedOrder.add(1, "Pages");
-		siteDropdownItemsInExpectedOrder.add(2, "Components");
-		siteDropdownItemsInExpectedOrder.add(3, "Taxonomy");
-		siteDropdownItemsInExpectedOrder.add(4, "Static Assets");
-		siteDropdownItemsInExpectedOrder.add(5, "Templates");
-		siteDropdownItemsInExpectedOrder.add(6, "Scripts");
-		siteDropdownItemsInExpectedOrder.add(7, "here");
-		siteDropdownItemsInExpectedOrder.add(8, "bug");
-		siteDropdownItemsInExpectedOrder.add(9, "Crafter News");
+		siteDropdownItemsInExpectedOrder = siteDropdownOrderItems.split(",");
 	}
 
 	@Parameters({"testId", "testUser"})
@@ -96,17 +82,9 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReview
 	public void verifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser(String testId, String testUser) {
 		logger.info("login to application with {} user", testUser);
 		loginPage.loginToCrafter(testUser, testUser);
-
-		getWebDriverManager().waitUntilLoginCloses();
-
 		logger.info("Go to Preview Page {}", testId);
 		this.homePage.goToPreviewPage(testId);
-
-		this.getWebDriverManager().waitForAnimation();
-
-		// Expand the site bar
-		this.getWebDriverManager().clickElement("xpath", siteDropdownElementXPath);
-
+		previewPage.clickSidebar();
 		// Check all the section are present;
 		WebElement dashboardLinkElement = this.getWebDriverManager()
 				.driverWaitUntilElementIsPresentAndDisplayed("xpath", dashboardLink);
@@ -145,7 +123,7 @@ public class VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReview
 		for (WebElement element : siteDropdownItems) {
 			this.getWebDriverManager().waitForAnimation();
 			this.getWebDriverManager().waitUntilSidebarOpens();
-			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder.get(currentIndex)),
+			Assert.assertTrue(element.getText().equals(siteDropdownItemsInExpectedOrder[currentIndex]),
 					"ERROR: Link Option: " + element.getText() + " is not in the correct order");
 			currentIndex++;
 		}

--- a/src/test/java/org/craftercms/studio/test/pages/CreateSitePage.java
+++ b/src/test/java/org/craftercms/studio/test/pages/CreateSitePage.java
@@ -261,7 +261,7 @@ public class CreateSitePage {
 	// Press on create site
 	public CreateSitePage clickOnCreateButton() {
 		this.driverManager.clickElement("xpath", createSiteButton);
-		Assert.assertTrue(driverManager.isTextInStudio("Please wait while your site is being created.."));
+		Assert.assertTrue(driverManager.isTextInStudio("Please wait while your site is being created."));
 		driverManager.waitUntilElementIsNotDisplayed("cssselector", creatingGearsImgCss, waitForCreateSite);
 		return this;
 	}

--- a/src/test/resources/testng_parallel.xml
+++ b/src/test/resources/testng_parallel.xml
@@ -857,6 +857,7 @@
 	<test name="Verify that the application displays the proper set of dropdown Sidebar components options on the Site Dropdown panel Test Case With Admin User">
 		<parameter name="testId" value="sitedropdown001"/>
 		<parameter name="blueprint" value="editorial"/>
+		<parameter name="siteDropdownOrderItems" value="Dashboard,Pages,Components,Taxonomy,Static Assets,Templates,Scripts,Site Config,Get support,Crafter News"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.sitedropdowntestcases.VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAdminUser"/>
 		</classes>
@@ -866,6 +867,7 @@
 		<parameter name="blueprint" value="editorial"/>
 		<parameter name="testUser" value="authorsidebar"/>
 		<parameter name="testGroup" value="site_author"/>
+		<parameter name="siteDropdownOrderItems" value="Dashboard,Pages,Components,Taxonomy,Static Assets,Templates,Scripts,Get support,Crafter News"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.sitedropdowntestcases.VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithAuthorUser"/>
 		</classes>
@@ -875,6 +877,7 @@
 		<parameter name="blueprint" value="editorial"/>
 		<parameter name="testUser" value="developersidebar"/>
 		<parameter name="testGroup" value="site_developer"/>
+		<parameter name="siteDropdownOrderItems" value="Dashboard,Pages,Components,Taxonomy,Static Assets,Templates,Scripts,Site Config,Get support,Crafter News"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.sitedropdowntestcases.VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithDeveloperUser"/>
 		</classes>
@@ -884,6 +887,7 @@
 		<parameter name="blueprint" value="editorial"/>
 		<parameter name="testUser" value="publishersidebar"/>
 		<parameter name="testGroup" value="site_publisher"/>
+		<parameter name="siteDropdownOrderItems" value="Dashboard,Pages,Components,Taxonomy,Static Assets,Templates,Scripts,Get support,Crafter News"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.sitedropdowntestcases.VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithPublisherUser"/>
 		</classes>
@@ -893,6 +897,7 @@
 		<parameter name="testId" value="sitedropdown005"/>
 		<parameter name="testUser" value="reviewersidebar"/>
 		<parameter name="testGroup" value="site_reviewer"/>
+		<parameter name="siteDropdownOrderItems" value="Dashboard,Pages,Components,Taxonomy,Static Assets,Templates,Scripts,Get support,Crafter News"/>
 		<classes>
 			<class name="org.craftercms.studio.test.cases.sitedropdowntestcases.VerifyTheSideBarDropdownOptionsUsingWebEditorialBlueprintWithReviewerUser"/>
 		</classes>


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
* Since the footer of Studio changes between CE and EE, move expected items in sidebar to parameters of each test so it is easier to change the parameters instead of each test class. 
* Change the direct click to sidebar to the appropriate method in PreviewPage
* Remove extra `.` in CreateSitePage


